### PR TITLE
fix(chat): render **double-star** segments as bold text (fixes #48)

### DIFF
--- a/search-engine/src/__tests__/message-formatting.service.test.tsx
+++ b/search-engine/src/__tests__/message-formatting.service.test.tsx
@@ -31,4 +31,20 @@ describe("message formatting service", () => {
     expect(onCitationClick).toHaveBeenNthCalledWith(2, "Romans 8:28");
     expect(onCitationClick).toHaveBeenNthCalledWith(3, "Genesis 1:1");
   });
+
+  it("renders text wrapped in double-stars as bold", () => {
+    render(<div>{renderMessageWithCitations("This is **important** text.", vi.fn())}</div>);
+
+    expect(screen.getByText("important")).toBeInTheDocument();
+    expect(screen.getByText("important").tagName).toBe("STRONG");
+  });
+
+  it("renders mixed bold markdown and clickable citations", () => {
+    const onCitationClick = vi.fn();
+    render(<div>{renderMessageWithCitations("**Important** [John 3:16]", onCitationClick)}</div>);
+
+    expect(screen.getByText("Important").tagName).toBe("STRONG");
+    fireEvent.click(screen.getByRole("button", { name: "John 3:16" }));
+    expect(onCitationClick).toHaveBeenCalledWith("John 3:16");
+  });
 });

--- a/search-engine/src/app/services/messageFormatting.tsx
+++ b/search-engine/src/app/services/messageFormatting.tsx
@@ -2,7 +2,7 @@ import { Fragment } from "react";
 import type { ReactNode } from "react";
 import type { ChatPart, RenderMessageWithCitations } from "../types/ui";
 
-const CITATION_REGEX = /(\[([^\]]+\d+:\d+(?:-\d+)?)\]|\(([^\)]+\d+:\d+(?:-\d+)?)\)|\*\*([^\*]+\d+:\d+(?:-\d+)?)\*\*)/g;
+const TOKEN_REGEX = /(\[([^\]]+\d+:\d+(?:-\d+)?)\]|\(([^\)]+\d+:\d+(?:-\d+)?)\)|\*\*([^\*]+)\*\*)/g;
 
 function splitCitationReferences(citation: string): string[] {
   const refs = citation
@@ -33,10 +33,12 @@ export const renderMessageWithCitations: RenderMessageWithCitations = (
   let lastIndex = 0;
   let index = 0;
 
-  for (const match of text.matchAll(CITATION_REGEX)) {
+  for (const match of text.matchAll(TOKEN_REGEX)) {
     const full = match[1];
-    const captured = (match[2] ?? match[3] ?? match[4] ?? "").trim();
-    if (!full || !captured || match.index == null) continue;
+    const citation = (match[2] ?? match[3] ?? "").trim();
+    const boldText = match[4] ?? "";
+
+    if (!full || match.index == null) continue;
 
     const start = match.index;
     if (start > lastIndex) {
@@ -44,10 +46,27 @@ export const renderMessageWithCitations: RenderMessageWithCitations = (
       index += 1;
     }
 
-    const references = splitCitationReferences(captured);
+    if (boldText.length > 0) {
+      nodes.push(
+        <strong key={`bold-${index}`} className="font-semibold">
+          {boldText}
+        </strong>
+      );
+
+      index += 1;
+      lastIndex = start + full.length;
+      continue;
+    }
+
+    if (!citation) {
+      lastIndex = start + full.length;
+      continue;
+    }
+
+    const references = splitCitationReferences(citation);
 
     nodes.push(
-      <Fragment key={`cite-group-${captured}-${index}`}>
+      <Fragment key={`cite-group-${citation}-${index}`}>
         {references.map((reference, refIndex) => (
           <Fragment key={`cite-item-${reference}-${refIndex}`}>
             {refIndex > 0 ? "; " : null}


### PR DESCRIPTION
## Summary
- update message formatting to render any `**...**` segment as bold text in assistant messages
- preserve clickable citation behavior for bracket and parenthesis references
- support mixed formatting, e.g. `**Important** [John 3:16]`

## Changes
- update token parsing and rendering in `search-engine/src/app/services/messageFormatting.tsx`
- add regression coverage in `search-engine/src/__tests__/message-formatting.service.test.tsx`
  - bold-only rendering
  - mixed bold + citation rendering

## Validation
- `npm run test:run -- message-formatting.service.test.tsx`

Closes #48