### PR TITLE
Phase 1: Meilisearch Infrastructure Setup (#54)

### DIFF
--- a/search-engine/env.example
+++ b/search-engine/env.example
@@ -8,4 +8,7 @@ EXTRACT_INPUT_PATH='../data/processed_bible.json'
 EXTRACT_OUTPUT_PATH='../data/raw_graph.enrich.json'
 EXTRACT_BOOKS="GEN,EXO,1SA,MAT,ACT,ROM,HEB"
 EXTRACT_DELAY_MS=20000
+MEILISEARCH_URL='http://localhost:7700'
+MEILISEARCH_API_KEY='masterKey'
+SKIP_MEILISEARCH='false'
 

--- a/search-engine/package-lock.json
+++ b/search-engine/package-lock.json
@@ -13,6 +13,7 @@
         "@langchain/openai": "^1.4.4",
         "ai": "^6.0.169",
         "framer-motion": "^12.38.0",
+        "meilisearch": "^0.58.0",
         "mongodb": "^7.1.1",
         "next": "^16.2.4",
         "react": "19.2.5",
@@ -6348,6 +6349,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/meilisearch": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.58.0.tgz",
+      "integrity": "sha512-MXFlU+JVG2I3tDI4brS3UHxEv2fjOROP24TPP16c8dGHTulb1kxMgXvKP0x4ImvUcsVVJFi4QXP0JNDS/TaWaw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/memory-pager": {

--- a/search-engine/package.json
+++ b/search-engine/package.json
@@ -22,6 +22,7 @@
     "@langchain/openai": "^1.4.4",
     "ai": "^6.0.169",
     "framer-motion": "^12.38.0",
+    "meilisearch": "^0.58.0",
     "mongodb": "^7.1.1",
     "next": "^16.2.4",
     "react": "19.2.5",

--- a/search-engine/src/lib/meilisearch-client.ts
+++ b/search-engine/src/lib/meilisearch-client.ts
@@ -1,0 +1,117 @@
+import { Meilisearch, type Index } from "meilisearch";
+
+const DEFAULT_MEILI_URL = "http://localhost:7700";
+const DEFAULT_RETRY_COUNT = 3;
+const DEFAULT_RETRY_DELAY_MS = 500;
+
+let singletonClient: Meilisearch | null = null;
+
+function getEnvBoolean(name: string, fallback = false): boolean {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
+}
+
+function getMeiliConfig() {
+  return {
+    host: process.env.MEILISEARCH_URL ?? DEFAULT_MEILI_URL,
+    apiKey: process.env.MEILISEARCH_API_KEY,
+  };
+}
+
+export function getMeilisearchClient(): Meilisearch {
+  if (singletonClient) return singletonClient;
+
+  singletonClient = new Meilisearch(getMeiliConfig());
+  return singletonClient;
+}
+
+export function isMeilisearchDisabled(): boolean {
+  return getEnvBoolean("SKIP_MEILISEARCH", false);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withMeilisearchRetry<T>(
+  operation: () => Promise<T>,
+  retries = DEFAULT_RETRY_COUNT,
+  delayMs = DEFAULT_RETRY_DELAY_MS
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= retries; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        await sleep(delayMs * attempt);
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+export async function checkMeilisearchHealth(client = getMeilisearchClient()): Promise<boolean> {
+  if (isMeilisearchDisabled()) return false;
+
+  try {
+    const health = await withMeilisearchRetry<{ status?: string }>(() => client.health());
+    return health.status === "available";
+  } catch {
+    return false;
+  }
+}
+
+const RANKING_RULES = ["words", "typo", "proximity", "attribute", "sort", "exactness"];
+
+async function ensureIndex(
+  client: Meilisearch,
+  uid: string,
+  primaryKey: string,
+  searchableAttributes: string[],
+  filterableAttributes: string[]
+): Promise<Index> {
+  const exists = await client.index(uid).fetchInfo().then(
+    () => true,
+    () => false
+  );
+
+  if (!exists) {
+    await withMeilisearchRetry(() => client.createIndex(uid, { primaryKey }));
+  }
+
+  const index = client.index(uid);
+  await withMeilisearchRetry(() =>
+    index.updateSettings({
+      searchableAttributes,
+      filterableAttributes,
+      rankingRules: RANKING_RULES,
+    })
+  );
+
+  return index;
+}
+
+export async function ensureMeilisearchIndexes(client = getMeilisearchClient()): Promise<void> {
+  if (isMeilisearchDisabled()) return;
+
+  await ensureIndex(
+    client,
+    "verses_bm25",
+    "id",
+    ["text", "book", "chapter"],
+    ["book", "testament", "version", "chapter"]
+  );
+
+  await ensureIndex(
+    client,
+    "entities_bm25",
+    "slug",
+    ["name", "aliases", "type", "description"],
+    ["type", "source_verse_id"]
+  );
+}

--- a/services/compose.yml
+++ b/services/compose.yml
@@ -12,11 +12,40 @@ services:
     volumes:
       - docdb-data:/docdb-data
       - ./scripts:/init_doc_db.d
+  meilisearch:
+    image: getmeili/meilisearch:v1.13
+    container_name: meilisearch
+    ports:
+      - "7700:7700"
+    environment:
+      - MEILI_ENV=development
+      - MEILI_MASTER_KEY=${MEILISEARCH_API_KEY:-masterKey}
+      - MEILI_NO_ANALYTICS=true
+    volumes:
+      - meilisearch-data:/meili_data
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7700/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+  meilisearch-init:
+    image: curlimages/curl:8.12.1
+    container_name: meilisearch_init
+    depends_on:
+      meilisearch:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "/scripts/init-meilisearch.sh"]
+    environment:
+      - MEILISEARCH_URL=${MEILISEARCH_URL:-http://meilisearch:7700}
+      - MEILISEARCH_API_KEY=${MEILISEARCH_API_KEY:-masterKey}
+    volumes:
+      - ./scripts:/scripts:ro
   bible-chat-scholar:
     image: ghcr.io/gasystarttask/bible-chat-scholar:main
     container_name: bible_chat_scholar
     depends_on:
       - documentdb
+      - meilisearch
     ports:
       - "3000:3000"
     extra_hosts:
@@ -28,5 +57,8 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GITHUB_TOKEN: ${GITHUB_TOKEN}
       COPILOTE_MODEL: ${COPILOTE_MODEL:-gpt-4o-mini}
+      MEILISEARCH_URL: ${MEILISEARCH_URL:-http://meilisearch:7700}
+      MEILISEARCH_API_KEY: ${MEILISEARCH_API_KEY:-masterKey}
 volumes:
   docdb-data: {}
+  meilisearch-data: {}

--- a/services/scripts/init-meilisearch.sh
+++ b/services/scripts/init-meilisearch.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+set -eu
+
+MEILI_URL="${MEILISEARCH_URL:-http://meilisearch:7700}"
+MEILI_KEY="${MEILISEARCH_API_KEY:-masterKey}"
+
+wait_for_meili() {
+  i=0
+  until curl -fsS "$MEILI_URL/health" >/dev/null 2>&1; do
+    i=$((i + 1))
+    if [ "$i" -ge 30 ]; then
+      echo "Meilisearch health check timed out"
+      exit 1
+    fi
+    sleep 2
+  done
+}
+
+create_index() {
+  uid="$1"
+  primary="$2"
+
+  curl -fsS -X POST "$MEILI_URL/indexes" \
+    -H "Authorization: Bearer $MEILI_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"uid\":\"$uid\",\"primaryKey\":\"$primary\"}" \
+    >/dev/null 2>&1 || true
+}
+
+update_settings() {
+  uid="$1"
+  filterable="$2"
+  searchable="$3"
+
+  curl -fsS -X PATCH "$MEILI_URL/indexes/$uid/settings" \
+    -H "Authorization: Bearer $MEILI_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"searchableAttributes\":$searchable,\"filterableAttributes\":$filterable,\"rankingRules\":[\"words\",\"typo\",\"proximity\",\"attribute\",\"sort\",\"exactness\"]}" \
+    >/dev/null
+}
+
+wait_for_meili
+
+create_index "verses_bm25" "id"
+update_settings "verses_bm25" '["book","testament","version","chapter"]' '["text","book","chapter"]'
+
+create_index "entities_bm25" "slug"
+update_settings "entities_bm25" '["type","source_verse_id"]' '["name","aliases","type","description"]'
+
+echo "Meilisearch indexes initialized"


### PR DESCRIPTION
Implements Phase 1 infrastructure for Meilisearch integration.

Scope:
- Add Meilisearch service and init job to compose
- Add environment variables for Meilisearch URL/API key
- Add Meilisearch client wrapper with health checks/retry/index setup

Key files:
- services/compose.yml
- services/scripts/init-meilisearch.sh
- search-engine/env.example
- search-engine/src/lib/meilisearch-client.ts

Refs #54