### PR TITLE
Phase 5: Testing & Validation (#53)

### DIFF
--- a/search-engine/src/__tests__/benchmarks/hybrid-search.bench.ts
+++ b/search-engine/src/__tests__/benchmarks/hybrid-search.bench.ts
@@ -1,0 +1,34 @@
+import { bench, describe } from "vitest";
+import { getDb } from "@search/lib/mongodb";
+import { HybridRetriever } from "@search/lib/hybrid-retriever";
+
+const runBench = process.env.RUN_HYBRID_BENCH === "true";
+const describeBench = runBench ? describe : describe.skip;
+
+describeBench("benchmark: hybrid retrieval", () => {
+  let retriever: HybridRetriever;
+
+  bench("vector only baseline", async () => {
+    if (!retriever) {
+      retriever = new HybridRetriever(await getDb());
+    }
+
+    await retriever.retrieve("Abraham", 5, 1, 0, 0, undefined, 0);
+  });
+
+  bench("bm25 weighted retrieval", async () => {
+    if (!retriever) {
+      retriever = new HybridRetriever(await getDb());
+    }
+
+    await retriever.retrieve("Abraham", 5, 0.48, 0.12, 0, undefined, 0.4);
+  });
+
+  bench("3-way hybrid retrieval", async () => {
+    if (!retriever) {
+      retriever = new HybridRetriever(await getDb());
+    }
+
+    await retriever.retrieve("Abraham", 5, 0.48, 0.12, 0, undefined, 0.4);
+  });
+});

--- a/search-engine/src/__tests__/context-injection.test.ts
+++ b/search-engine/src/__tests__/context-injection.test.ts
@@ -35,6 +35,8 @@ describe("context-injection", () => {
     expect(context.text).toContain("PARENT_OF -> Manassé");
     expect(context.text).toContain("Yossef => Joseph");
     expect(context.references).toEqual(["Genèse 46:19"]);
+    expect(context.sourceReferences.hybrid).toEqual(["Genèse 46:19"]);
+    expect(context.sourceReferences.bm25).toEqual([]);
   });
 
   it("builds strict grounding prompt rules in French", () => {

--- a/search-engine/src/__tests__/grounded-answer.test.ts
+++ b/search-engine/src/__tests__/grounded-answer.test.ts
@@ -89,8 +89,8 @@ vi.mock("@search/lib/context-injection", () => ({
   generateGroundedAnswerStream: generateGroundedAnswerStreamMock,
 }));
 
-function buildRequest(body: object): NextRequest {
-  return new NextRequest("http://localhost:3000/api/grounded-answer", {
+function buildRequest(body: object, url = "http://localhost:3000/api/grounded-answer"): NextRequest {
+  return new NextRequest(url, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
@@ -156,6 +156,27 @@ describe("POST /api/grounded-answer", () => {
     const json = await res.json();
     expect(json.metadata.source).toBe("retrieved-context");
     expect(json.metadata.retrieval).toBeTruthy();
+  });
+
+  it("disables BM25 when disableBM25 query param is true", async () => {
+    const POST = await getPOST();
+    const res = await POST(
+      buildRequest(
+        { query: "Qui est le fils de Joseph ?" },
+        "http://localhost:3000/api/grounded-answer?disableBM25=true"
+      )
+    );
+
+    expect(res.status).toBe(200);
+    expect(retrieveMock).toHaveBeenCalledWith(
+      "Qui est le fils de Joseph ?",
+      6,
+      0.8,
+      0.2,
+      0,
+      undefined,
+      0
+    );
   });
 
   it("returns uncertain answer for out-of-domain query", async () => {

--- a/search-engine/src/__tests__/hybrid-search.test.ts
+++ b/search-engine/src/__tests__/hybrid-search.test.ts
@@ -172,6 +172,7 @@ describe("POST /api/hybrid-search", () => {
       latencyMs: 0,
       filters: undefined,
       k: 5,
+      bm25Weight: 0,
     });
   });
 

--- a/search-engine/src/__tests__/integration/hybrid-search.test.ts
+++ b/search-engine/src/__tests__/integration/hybrid-search.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+const runLive = process.env.RUN_LIVE_HYBRID_TESTS === "true";
+const describeLive = runLive ? describe : describe.skip;
+
+async function getLiveDeps() {
+  const [{ getDb }, { HybridRetriever }, { ensureMeilisearchIndexes }] = await Promise.all([
+    import("@search/lib/mongodb"),
+    import("@search/lib/hybrid-retriever"),
+    import("@search/lib/meilisearch-client"),
+  ]);
+
+  return { getDb, HybridRetriever, ensureMeilisearchIndexes };
+}
+
+describeLive("integration: hybrid retriever with mongodb + meilisearch", () => {
+  it("returns fused results from vector/graph/bm25 without breaking schema", async () => {
+    const { getDb, HybridRetriever, ensureMeilisearchIndexes } = await getLiveDeps();
+    const db = await getDb();
+    await ensureMeilisearchIndexes();
+
+    const retriever = new HybridRetriever(db);
+    const result = await retriever.retrieve(
+      "Abraham en Egypte",
+      6,
+      0.48,
+      0.12,
+      0,
+      { book: "Genèse", testament: "Ancien Testament" },
+      0.4
+    );
+
+    expect(result.verses.length).toBeGreaterThan(0);
+    expect(result.metadata.vectorWeight + result.metadata.graphWeight + result.metadata.bm25Weight).toBe(1);
+    expect(result.metadata.totalBM25Results).toBeGreaterThanOrEqual(0);
+  });
+
+  it("supports disableBM25 scenario while preserving retrieval", async () => {
+    const { getDb, HybridRetriever } = await getLiveDeps();
+    const db = await getDb();
+    const retriever = new HybridRetriever(db);
+
+    const withBm25 = await retriever.retrieve("Jésus", 5, 0.63, 0.07, 0, undefined, 0.3);
+    const withoutBm25 = await retriever.retrieve("Jésus", 5, 0.63, 0.07, 0, undefined, 0);
+
+    expect(withoutBm25.verses.length).toBeGreaterThan(0);
+    expect(withoutBm25.metadata.totalBM25Results).toBe(0);
+    expect(withBm25.verses.length).toBeGreaterThan(0);
+  });
+});

--- a/search-engine/src/__tests__/query-router.test.ts
+++ b/search-engine/src/__tests__/query-router.test.ts
@@ -33,4 +33,25 @@ describe("query-router French heuristics", () => {
     expect(result.graphWeight).toBe(0.3);
     expect(result.bm25Weight).toBe(0.4);
   });
+
+  it("applies chronology bm25 tuning", async () => {
+    const result = await routeQuery({ query: "Quand David regna-t-il ?" });
+
+    expect(result.intent).toBe("CHRONOLOGY");
+    expect(result.bm25Weight).toBe(0.25);
+  });
+
+  it("applies theology bm25 tuning", async () => {
+    const result = await routeQuery({ query: "Que dit la Bible sur la grace ?" });
+
+    expect(result.intent).toBe("THEOLOGY");
+    expect(result.bm25Weight).toBe(0.3);
+  });
+
+  it("applies general bm25 tuning", async () => {
+    const result = await routeQuery({ query: "Parle-moi d'Abraham" });
+
+    expect(result.intent).toBe("GENERAL");
+    expect(result.bm25Weight).toBe(0.4);
+  });
 });

--- a/search-engine/src/app/api/grounded-answer/route.ts
+++ b/search-engine/src/app/api/grounded-answer/route.ts
@@ -38,9 +38,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     k,
     vectorWeight,
     graphWeight,
+    bm25Weight,
     filters,
     minScore = 0.0,
   } = body;
+
+  const disableBM25 = req.nextUrl.searchParams.get("disableBM25") === "true";
 
   if (!query || typeof query !== "string" || query.trim().length === 0) {
     return NextResponse.json(
@@ -73,6 +76,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           k,
           vectorWeight,
           graphWeight,
+          bm25Weight,
           filters,
         },
       });
@@ -85,7 +89,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         routing.vectorWeight,
         routing.graphWeight,
         minScore,
-        routing.filters
+        routing.filters,
+        disableBM25 ? 0 : routing.bm25Weight
       );
 
       verses = retrievalResult.verses;
@@ -100,6 +105,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           latencyMs: routing.latencyMs,
           filters: routing.filters,
           k: routing.k,
+          bm25Weight: disableBM25 ? 0 : routing.bm25Weight,
+          bm25Disabled: disableBM25,
         },
       };
 

--- a/search-engine/src/app/api/hybrid-search/route.ts
+++ b/search-engine/src/app/api/hybrid-search/route.ts
@@ -109,6 +109,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           latencyMs: routing.latencyMs,
           filters: routing.filters,
           k: routing.k,
+          bm25Weight: routing.bm25Weight,
         },
       },
     };

--- a/search-engine/src/lib/__tests__/hybrid-retriever.test.ts
+++ b/search-engine/src/lib/__tests__/hybrid-retriever.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("openai", () => {
+  return {
+    default: class OpenAI {
+      embeddings = {
+        create: vi.fn(),
+      };
+    },
+  };
+});
+
+async function getHybridRetrieverClass() {
+  const mod = await import("@search/lib/hybrid-retriever");
+  return mod.HybridRetriever;
+}
+
+async function createRetriever() {
+  const HybridRetriever = await getHybridRetrieverClass();
+  const db = {
+    collection: vi.fn().mockReturnValue({
+      find: vi.fn(),
+      aggregate: vi.fn(),
+    }),
+  };
+
+  return new HybridRetriever(db as never);
+}
+
+describe("hybrid-retriever.retrieve", () => {
+  it("normalizes three-way weights when input sum is not 1.0", async () => {
+    const retriever = await createRetriever();
+
+    vi.spyOn(retriever, "vectorSearch").mockResolvedValue([
+      {
+        id: "b.GEN.1.1",
+        reference: "Genèse 1:1",
+        text: "Au commencement...",
+        score: 1,
+        source: "vector",
+        entitySlugs: ["abraham"],
+      },
+    ] as never);
+    vi.spyOn(retriever, "graphSearch").mockResolvedValue([]);
+    vi.spyOn(retriever, "bm25Search").mockResolvedValue([]);
+    vi.spyOn(retriever, "augmentWithEntityFacts").mockResolvedValue([]);
+
+    const result = await retriever.retrieve("creation", 5, 2, 1, 0, undefined, 0.5);
+    const total = result.metadata.vectorWeight + result.metadata.graphWeight + result.metadata.bm25Weight;
+
+    expect(total).toBe(1);
+    expect(result.metadata.vectorWeight).toBeGreaterThan(0);
+    expect(result.metadata.graphWeight).toBeGreaterThan(0);
+    expect(result.metadata.bm25Weight).toBeGreaterThan(0);
+  });
+
+  it("fuses vector, graph, and bm25 results with deduplication", async () => {
+    const retriever = await createRetriever();
+
+    vi.spyOn(retriever, "vectorSearch").mockResolvedValue([
+      {
+        id: "b.GEN.1.1",
+        reference: "Genèse 1:1",
+        text: "Au commencement...",
+        score: 1,
+        source: "vector",
+        entitySlugs: ["abraham"],
+      },
+    ] as never);
+
+    vi.spyOn(retriever, "graphSearch").mockResolvedValue([
+      {
+        id: "b.GEN.1.1",
+        reference: "Genèse 1:1",
+        text: "Au commencement...",
+        score: 0.9,
+        source: "graph",
+        entitySlugs: ["abraham"],
+      },
+      {
+        id: "b.GEN.1.2",
+        reference: "Genèse 1:2",
+        text: "La terre était informe...",
+        score: 0.7,
+        source: "graph",
+        entitySlugs: ["terre"],
+      },
+    ] as never);
+
+    vi.spyOn(retriever, "bm25Search").mockResolvedValue([
+      {
+        id: "b.GEN.1.2",
+        reference: "Genèse 1:2",
+        text: "La terre était informe...",
+        score: 1,
+        source: "bm25",
+        entitySlugs: ["terre"],
+      },
+    ] as never);
+
+    vi.spyOn(retriever, "augmentWithEntityFacts").mockResolvedValue([]);
+
+    const result = await retriever.retrieve("terre informe", 5, 0.5, 0.2, 0, undefined, 0.3);
+
+    expect(result.verses.length).toBe(2);
+    expect(result.verses.every((v) => v.source === "hybrid")).toBe(true);
+    expect(result.metadata.totalVectorResults).toBe(1);
+    expect(result.metadata.totalGraphResults).toBe(2);
+    expect(result.metadata.totalBM25Results).toBe(1);
+  });
+
+  it("supports graceful degradation when bm25 returns no hits", async () => {
+    const retriever = await createRetriever();
+
+    vi.spyOn(retriever, "vectorSearch").mockResolvedValue([
+      {
+        id: "b.GEN.1.1",
+        reference: "Genèse 1:1",
+        text: "Au commencement...",
+        score: 1,
+        source: "vector",
+        entitySlugs: ["abraham"],
+      },
+    ] as never);
+    vi.spyOn(retriever, "graphSearch").mockResolvedValue([]);
+    vi.spyOn(retriever, "bm25Search").mockResolvedValue([]);
+    vi.spyOn(retriever, "augmentWithEntityFacts").mockResolvedValue([]);
+
+    const result = await retriever.retrieve("creation", 5, 0.7, 0.2, 0, undefined, 0.1);
+
+    expect(result.verses.length).toBeGreaterThan(0);
+    expect(result.metadata.totalBM25Results).toBe(0);
+  });
+});

--- a/search-engine/src/lib/context-injection.ts
+++ b/search-engine/src/lib/context-injection.ts
@@ -15,6 +15,7 @@ function createCopilotClient(): OpenAI {
 const DEFAULT_MODEL = process.env.GROUNDED_ANSWER_MODEL ?? "gpt-4o-mini";
 const UNKNOWN_RESPONSE = "Je ne sais pas d'après les Écritures fournies.";
 const PROMPT_VERSION = "us-010.v2";
+const CONTEXT_DEBUG = process.env.CONTEXT_INJECTION_DEBUG === "true";
 
 const OUT_OF_DOMAIN_MARKERS = [
   "elon musk", "einstein", "napoleon", "hitler", "newton", "shakespeare",
@@ -30,6 +31,12 @@ export function isOutOfDomainQuery(query: string): boolean {
 export interface AssembledContext {
   text: string;
   references: string[];
+  sourceReferences: {
+    vector: string[];
+    graph: string[];
+    bm25: string[];
+    hybrid: string[];
+  };
 }
 
 export interface GroundedAnswerResult {
@@ -65,7 +72,17 @@ function canonicalizeRelationType(rawType: string): string {
 }
 
 export function assembleHybridContext(verses: VerseResult[], entityFacts: EntityFact[]): AssembledContext {
-  const verseLines = verses.map((verse) => `[${verse.reference}] ${verse.text}`);
+  const sourceReferences = {
+    vector: verses.filter((verse) => verse.source === "vector").map((verse) => verse.reference),
+    graph: verses.filter((verse) => verse.source === "graph").map((verse) => verse.reference),
+    bm25: verses.filter((verse) => verse.source === "bm25").map((verse) => verse.reference),
+    hybrid: verses.filter((verse) => verse.source === "hybrid").map((verse) => verse.reference),
+  };
+
+  const verseLines = verses.map((verse) => {
+    const debugPrefix = CONTEXT_DEBUG && verse.source === "bm25" ? "[BM25 match:] " : "";
+    return `[${verse.reference}] ${debugPrefix}${verse.text}`;
+  });
   const aliasLines: string[] = [];
 
   const entityLines = entityFacts.map((entity) => {
@@ -107,6 +124,7 @@ export function assembleHybridContext(verses: VerseResult[], entityFacts: Entity
   return {
     text,
     references: verses.map((verse) => verse.reference),
+    sourceReferences,
   };
 }
 

--- a/search-engine/src/types/grounded-answer.ts
+++ b/search-engine/src/types/grounded-answer.ts
@@ -11,6 +11,7 @@ export interface GroundedAnswerRequest {
   k?: number;
   vectorWeight?: number;
   graphWeight?: number;
+  bm25Weight?: number;
   filters?: HybridFilters;
   minScore?: number;
 }

--- a/search-engine/src/types/hybrid.ts
+++ b/search-engine/src/types/hybrid.ts
@@ -60,6 +60,8 @@ export interface HybridSearchResponse {
       latencyMs: number;
       filters?: HybridFilters;
       k: number;
+      bm25Weight?: number;
+      bm25Disabled?: boolean;
     };
   };
 }


### PR DESCRIPTION
Implements Phase 5 test coverage additions on top of Phase 4.

Scope:
- Add unit tests for hybrid retriever RRF-3 and fallback behavior
- Add gated integration tests for live MongoDB + Meilisearch
- Add benchmark suite scaffold for hybrid retrieval
- Extend query router coverage for intent-based BM25 tuning

Key files:
- search-engine/src/lib/__tests__/hybrid-retriever.test.ts
- search-engine/src/__tests__/integration/hybrid-search.test.ts
- search-engine/src/__tests__/benchmarks/hybrid-search.bench.ts
- search-engine/src/__tests__/query-router.test.ts

Refs #53