### PR TITLE
Phase 4: RAG Pipeline Update (grounded-answer integration) (#50)

### DIFF
--- a/search-engine/src/__tests__/context-injection.test.ts
+++ b/search-engine/src/__tests__/context-injection.test.ts
@@ -35,6 +35,8 @@ describe("context-injection", () => {
     expect(context.text).toContain("PARENT_OF -> Manassé");
     expect(context.text).toContain("Yossef => Joseph");
     expect(context.references).toEqual(["Genèse 46:19"]);
+    expect(context.sourceReferences.hybrid).toEqual(["Genèse 46:19"]);
+    expect(context.sourceReferences.bm25).toEqual([]);
   });
 
   it("builds strict grounding prompt rules in French", () => {

--- a/search-engine/src/__tests__/grounded-answer.test.ts
+++ b/search-engine/src/__tests__/grounded-answer.test.ts
@@ -89,8 +89,8 @@ vi.mock("@search/lib/context-injection", () => ({
   generateGroundedAnswerStream: generateGroundedAnswerStreamMock,
 }));
 
-function buildRequest(body: object): NextRequest {
-  return new NextRequest("http://localhost:3000/api/grounded-answer", {
+function buildRequest(body: object, url = "http://localhost:3000/api/grounded-answer"): NextRequest {
+  return new NextRequest(url, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
@@ -156,6 +156,27 @@ describe("POST /api/grounded-answer", () => {
     const json = await res.json();
     expect(json.metadata.source).toBe("retrieved-context");
     expect(json.metadata.retrieval).toBeTruthy();
+  });
+
+  it("disables BM25 when disableBM25 query param is true", async () => {
+    const POST = await getPOST();
+    const res = await POST(
+      buildRequest(
+        { query: "Qui est le fils de Joseph ?" },
+        "http://localhost:3000/api/grounded-answer?disableBM25=true"
+      )
+    );
+
+    expect(res.status).toBe(200);
+    expect(retrieveMock).toHaveBeenCalledWith(
+      "Qui est le fils de Joseph ?",
+      6,
+      0.8,
+      0.2,
+      0,
+      undefined,
+      0
+    );
   });
 
   it("returns uncertain answer for out-of-domain query", async () => {

--- a/search-engine/src/__tests__/hybrid-search.test.ts
+++ b/search-engine/src/__tests__/hybrid-search.test.ts
@@ -172,6 +172,7 @@ describe("POST /api/hybrid-search", () => {
       latencyMs: 0,
       filters: undefined,
       k: 5,
+      bm25Weight: 0,
     });
   });
 

--- a/search-engine/src/app/api/grounded-answer/route.ts
+++ b/search-engine/src/app/api/grounded-answer/route.ts
@@ -38,9 +38,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     k,
     vectorWeight,
     graphWeight,
+    bm25Weight,
     filters,
     minScore = 0.0,
   } = body;
+
+  const disableBM25 = req.nextUrl.searchParams.get("disableBM25") === "true";
 
   if (!query || typeof query !== "string" || query.trim().length === 0) {
     return NextResponse.json(
@@ -73,6 +76,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           k,
           vectorWeight,
           graphWeight,
+          bm25Weight,
           filters,
         },
       });
@@ -85,7 +89,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         routing.vectorWeight,
         routing.graphWeight,
         minScore,
-        routing.filters
+        routing.filters,
+        disableBM25 ? 0 : routing.bm25Weight
       );
 
       verses = retrievalResult.verses;
@@ -100,6 +105,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           latencyMs: routing.latencyMs,
           filters: routing.filters,
           k: routing.k,
+          bm25Weight: disableBM25 ? 0 : routing.bm25Weight,
+          bm25Disabled: disableBM25,
         },
       };
 

--- a/search-engine/src/app/api/hybrid-search/route.ts
+++ b/search-engine/src/app/api/hybrid-search/route.ts
@@ -109,6 +109,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           latencyMs: routing.latencyMs,
           filters: routing.filters,
           k: routing.k,
+          bm25Weight: routing.bm25Weight,
         },
       },
     };

--- a/search-engine/src/lib/context-injection.ts
+++ b/search-engine/src/lib/context-injection.ts
@@ -15,6 +15,7 @@ function createCopilotClient(): OpenAI {
 const DEFAULT_MODEL = process.env.GROUNDED_ANSWER_MODEL ?? "gpt-4o-mini";
 const UNKNOWN_RESPONSE = "Je ne sais pas d'après les Écritures fournies.";
 const PROMPT_VERSION = "us-010.v2";
+const CONTEXT_DEBUG = process.env.CONTEXT_INJECTION_DEBUG === "true";
 
 const OUT_OF_DOMAIN_MARKERS = [
   "elon musk", "einstein", "napoleon", "hitler", "newton", "shakespeare",
@@ -30,6 +31,12 @@ export function isOutOfDomainQuery(query: string): boolean {
 export interface AssembledContext {
   text: string;
   references: string[];
+  sourceReferences: {
+    vector: string[];
+    graph: string[];
+    bm25: string[];
+    hybrid: string[];
+  };
 }
 
 export interface GroundedAnswerResult {
@@ -65,7 +72,17 @@ function canonicalizeRelationType(rawType: string): string {
 }
 
 export function assembleHybridContext(verses: VerseResult[], entityFacts: EntityFact[]): AssembledContext {
-  const verseLines = verses.map((verse) => `[${verse.reference}] ${verse.text}`);
+  const sourceReferences = {
+    vector: verses.filter((verse) => verse.source === "vector").map((verse) => verse.reference),
+    graph: verses.filter((verse) => verse.source === "graph").map((verse) => verse.reference),
+    bm25: verses.filter((verse) => verse.source === "bm25").map((verse) => verse.reference),
+    hybrid: verses.filter((verse) => verse.source === "hybrid").map((verse) => verse.reference),
+  };
+
+  const verseLines = verses.map((verse) => {
+    const debugPrefix = CONTEXT_DEBUG && verse.source === "bm25" ? "[BM25 match:] " : "";
+    return `[${verse.reference}] ${debugPrefix}${verse.text}`;
+  });
   const aliasLines: string[] = [];
 
   const entityLines = entityFacts.map((entity) => {
@@ -107,6 +124,7 @@ export function assembleHybridContext(verses: VerseResult[], entityFacts: Entity
   return {
     text,
     references: verses.map((verse) => verse.reference),
+    sourceReferences,
   };
 }
 

--- a/search-engine/src/types/grounded-answer.ts
+++ b/search-engine/src/types/grounded-answer.ts
@@ -11,6 +11,7 @@ export interface GroundedAnswerRequest {
   k?: number;
   vectorWeight?: number;
   graphWeight?: number;
+  bm25Weight?: number;
   filters?: HybridFilters;
   minScore?: number;
 }

--- a/search-engine/src/types/hybrid.ts
+++ b/search-engine/src/types/hybrid.ts
@@ -60,6 +60,8 @@ export interface HybridSearchResponse {
       latencyMs: number;
       filters?: HybridFilters;
       k: number;
+      bm25Weight?: number;
+      bm25Disabled?: boolean;
     };
   };
 }


### PR DESCRIPTION
Implements Phase 4 grounded-answer integration on top of Phase 3.

Scope:
- Integrate BM25 weight/control into grounded-answer flow
- Add optional disableBM25 query parameter for A/B control
- Extend context-injection tracking for source refs and BM25 debug tags
- Preserve backward compatibility for existing API behavior

Key files:
- search-engine/src/app/api/grounded-answer/route.ts
- search-engine/src/lib/context-injection.ts
- search-engine/src/types/grounded-answer.ts
- search-engine/src/types/hybrid.ts

Refs #50