### PR TITLE
Phase 6: Documentation & Deployment (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 [![Security](https://img.shields.io/github/issues-search/gasystarttask/bible-sg?query=is%3Aopen+label%3Asecurity&label=security%20issues)](https://github.com/gasystarttask/bible-sg/issues?q=is%3Aopen+label%3Asecurity)
 [![Code Quality](https://img.shields.io/github/actions/workflow/status/gasystarttask/bible-sg/search-engine-openapi.yml?label=code%20quality)](https://github.com/gasystarttask/bible-sg/actions/workflows/search-engine-openapi.yml)
 
-Bible Chat Scholar is a ~~proof-of-concept~~ Bible AI engine using semantic search (vector embeddings) and a roadmap toward RAG + knowledge graph capabilities.
+Bible Chat Scholar is a ~~proof-of-concept~~ Bible AI engine using hybrid retrieval (vector embeddings + knowledge graph + BM25 full-text) for grounded biblical answers.
 
 ## What it includes
 
 - XML → JSON parsing pipeline
 - Verse embedding/vectorization pipeline
 - Semantic Search API in Next.js
-- Foundation for hybrid retrieval (vector + graph)
+- Hybrid retriever with vector + graph + BM25 fusion
+- Grounded-answer streaming API with citation enforcement
 
 ## Architecture diagram
 
@@ -21,14 +22,17 @@ Bible Chat Scholar is a ~~proof-of-concept~~ Bible AI engine using semantic sear
 
 - Next.js (App Router, TypeScript)
 - DocumentDB / Mongo-compatible vector search
+- Meilisearch (BM25 full-text search)
 - OpenAI embeddings (`text-embedding-3-small`)
 - LangChain
 
 ## Quick start
 
 1. Install dependencies
-2. Configure environment variables (`DATABASE_URL`, `OPENAI_API_KEY`, etc.)
-3. Run app and pipelines as needed
+2. Start local services (`docker compose -f services/compose.yml up -d`)
+3. Configure environment variables (`DATABASE_URL`, `OPENAI_API_KEY`, `MEILISEARCH_URL`, `MEILISEARCH_API_KEY`, etc.)
+4. Index Meilisearch data (`npm run reindex:meilisearch` from `search-engine`)
+5. Run app and pipelines as needed
 
 ## Documentation references
 

--- a/docs/architecture-rag-graph-router.md
+++ b/docs/architecture-rag-graph-router.md
@@ -2,10 +2,10 @@
 
 ## System Overview
 
-The Bible Search Engine combines three interacting systems to deliver accurate, contextualized biblical answers:
+The Bible Search Engine combines four interacting systems to deliver accurate, contextualized biblical answers:
 
 1. **Query Router (US-009)**: Intent classification + adaptive parameter tuning
-2. **Hybrid Retriever**: Vector + Graph search with adaptive fanout
+2. **Hybrid Retriever**: Vector + Graph + BM25 search with adaptive fanout
 3. **Context Injection & Grounded Answer (US-010)**: LLM-based answer generation with citation enforcement
 4. **Streaming API (US-011)**: Real-time token streaming to frontend
 
@@ -24,11 +24,11 @@ graph TD
     B2 -->|resolve context| C
     
     C -->|heuristic + LLM| D["Intent Classification"]
-    D -->|THEOLOGY| E["Weight Profile:<br/>vw=0.9, gw=0.1, k=5"]
-    D -->|GENEALOGY| F["Weight Profile:<br/>vw=0.1, gw=0.9, k=6<br/>Fast: vw=0.8, gw=0.2"]
-    D -->|GEOGRAPHY| G["Weight Profile:<br/>vw=0.5, gw=0.5, k=8"]
-    D -->|CHRONOLOGY| H["Weight Profile:<br/>vw=0.4, gw=0.6, k=8"]
-    D -->|GENERAL| I["Weight Profile:<br/>vw=0.8, gw=0.2, k=5"]
+    D -->|THEOLOGY| E["Weight Profile:<br/>vw=0.63, gw=0.07, bw=0.3, k=5"]
+    D -->|GENEALOGY| F["Weight Profile:<br/>vw=0.15, gw=0.7, bw=0.15, k=6<br/>Fast: vw=0.68, gw=0.17, bw=0.15"]
+    D -->|GEOGRAPHY| G["Weight Profile:<br/>vw=0.3, gw=0.3, bw=0.4, k=8"]
+    D -->|CHRONOLOGY| H["Weight Profile:<br/>vw=0.35, gw=0.4, bw=0.25, k=8"]
+    D -->|GENERAL| I["Weight Profile:<br/>vw=0.48, gw=0.12, bw=0.4, k=5"]
     
     E --> J["Hybrid Retriever"]
     F --> J
@@ -47,9 +47,11 @@ graph TD
     N --> P
     O --> P
     O --> Q
+    O --> Q2["BM25 Search (Meilisearch)"]
     
-    P --> R["Reciprocal Rank<br/>Fusion"]
+    P --> R["Reciprocal Rank<br/>Fusion (RRF-3)"]
     Q --> R
+    Q2 --> R
     
     R -->|top k verses| S["Entity Fact<br/>Augmentation"]
     S -->|genealogy query?| T["Lexical Rerank<br/>by Query Overlap"]
@@ -115,7 +117,7 @@ Output: { intent, vectorWeight, graphWeight, k, filters }
 
 **File**: `src/lib/hybrid-retriever.ts`
 
-**Purpose**: Dual-path search combining semantic (vector) and structural (graph) retrieval
+**Purpose**: Three-path search combining semantic (vector), structural (graph), and lexical (BM25) retrieval
 
 **Vector Path** (`vectorSearch`):
 - Generate/cache query embedding via OpenAI
@@ -129,6 +131,12 @@ Output: { intent, vectorWeight, graphWeight, k, filters }
 - Apply book/testament filters
 - Fallback regex if no primary hits
 - Return top k results with `source: "graph"`
+
+**BM25 Path** (`bm25Search`):
+- Queries `verses_bm25` in Meilisearch
+- Applies optional filters (`book`, normalized `testament`)
+- Returns ranked lexical matches with `source: "bm25"`
+- Uses graceful degradation and circuit breaker fallback when Meilisearch is unavailable
 
 **Adaptive Fanout** (New):
 ```
@@ -239,6 +247,14 @@ Result: TTFT (Time To First Token) < 1.5s after retrieval completes; no monolith
 ---
 
 ## Performance Characteristics
+
+### RRF-3 Formula
+
+$$
+score(d) = w_v \cdot \frac{1}{k + rank_v(d)} + w_g \cdot \frac{1}{k + rank_g(d)} + w_b \cdot \frac{1}{k + rank_b(d)}
+$$
+
+Where $w_v + w_g + w_b = 1$ and missing ranks contribute 0.
 
 ### Latency Breakdown
 

--- a/docs/hybrid-retriever.md
+++ b/docs/hybrid-retriever.md
@@ -5,7 +5,8 @@
 
 - vector search (semantic similarity with OpenAI embeddings + MongoDB vector index),
 - graph search (entity-driven retrieval with `entity_slugs`),
-- rank fusion (RRF) to merge both result sets.
+- BM25 full-text search (Meilisearch),
+- rank fusion (RRF-3) to merge all result sets.
 
 It returns:
 - ranked verses,
@@ -18,17 +19,21 @@ It returns:
 
 1. Build a cache key from query + parameters.
 2. Return cached payload if available (`retrieveCache`).
-3. Apply **adaptive fanout**:
+3. Normalize `vectorWeight`, `graphWeight`, and `bm25Weight` to sum to 1.0.
+4. Apply **adaptive fanout**:
    - If `vectorWeight <= 0.1`: skip vector search entirely (resolve to empty).
-   - If `graphWeight <= 0.25`: skip graph search entirely (resolve to empty).
+   - If `graphWeight <= 0.1`: skip graph search entirely (resolve to empty).
+   - If `bm25Weight <= 0.05`: skip BM25 search entirely (resolve to empty).
    - Otherwise: use fanout multiplier based on intent:
      - `vectorSearchK = (vectorWeight <= 0.15) ? max(4, k) : k * 2`
-     - `graphSearchK = (graphWeight >= 0.8) ? max(k + 2, 8) : k * 2`
-4. Run in parallel (both or single-sided):
+     - `graphSearchK = (graphWeight >= 0.7) ? max(k + 2, 8) : k * 2`
+     - `bm25SearchK = (bm25Weight >= 0.35) ? max(k + 3, 10) : k * 2`
+5. Run in parallel (all active retrievers):
    - `vectorSearch(query, vectorSearchK, filters)`
    - `graphSearch(query, graphSearchK, filters)`
-5. Merge both lists using `reciprocalRankFusion(...)`.
-6. Keep top `k` verses above `minScore`.
+   - `bm25Search(query, bm25SearchK, filters)`
+6. Merge all lists using `reciprocalRankFusion(...)`.
+7. Keep top `k` verses above `minScore`.
 7. Resolve entity slugs:
    - first from `verse.entitySlugs`,
    - fallback to `extractMentionedEntities(...)` if missing.
@@ -53,11 +58,25 @@ It returns:
 - Uses limited regex fallback only if no primary hits.
 - Returns `RankedVerseResult[]` with source `"graph"`.
 
-### 3) Fusion: `reciprocalRankFusion`
-- Combines vector + graph rankings with configurable weights:
+### 3) `bm25Search`
+- Uses Meilisearch `verses_bm25` index.
+- Converts testament filters to `Old/New` values.
+- Adds circuit breaker fallback:
+   - after 3 consecutive errors, BM25 is disabled for 5 minutes.
+   - `SKIP_MEILISEARCH=true` disables BM25 immediately.
+
+### 4) Fusion: `reciprocalRankFusion`
+- Combines vector + graph + BM25 rankings with configurable weights:
   - `vectorWeight`
   - `graphWeight`
+   - `bm25Weight`
 - Produces final hybrid score and source `"hybrid"`.
+
+RRF-3 formula:
+
+$$
+score(d) = w_v \cdot \frac{1}{k + rank_v(d)} + w_g \cdot \frac{1}{k + rank_g(d)} + w_b \cdot \frac{1}{k + rank_b(d)}
+$$
 
 ---
 
@@ -110,13 +129,13 @@ Both caches are in-memory TTL maps with max-size eviction.
 
 ## Weight presets (from Query Router)
 
-| Intent | Vector | Graph | k | Use Case |
-|--------|--------|-------|---|----------|
-| **THEOLOGY** | 0.9 | 0.1 | 5 | Thematic: "What does Bible say about faith?" |
-| **GENEALOGY** | 0.1 | 0.9 | 6 | Kinship: "Father of Jacob?" → *fast profile: 0.8/0.2 after routing* |
-| **GEOGRAPHY** | 0.5 | 0.5 | 8 | Places: "Abraham in Egypt?" |
-| **CHRONOLOGY** | 0.4 | 0.6 | 8 | Timeline: "What happened after X?" |
-| **GENERAL** | 0.8 | 0.2 | 5 | Fallback (vector-only with graph skip) |
+| Intent | Vector | Graph | BM25 | k | Use Case |
+|--------|--------|-------|------|---|----------|
+| **THEOLOGY** | 0.63 | 0.07 | 0.30 | 5 | Thematic: "What does Bible say about faith?" |
+| **GENEALOGY** | 0.15 | 0.70 | 0.15 | 6 | Kinship: "Father of Jacob?" |
+| **GEOGRAPHY** | 0.30 | 0.30 | 0.40 | 8 | Places: "Abraham in Egypt?" |
+| **CHRONOLOGY** | 0.35 | 0.40 | 0.25 | 8 | Timeline: "What happened after X?" |
+| **GENERAL** | 0.48 | 0.12 | 0.40 | 5 | General fallback with lexical emphasis |
 
 *Note: Kinship fast profile applied dynamically by router when direct kinship detected.*
 
@@ -131,14 +150,15 @@ Both caches are in-memory TTL maps with max-size eviction.
 ### Solutions
 1. **Kinship fast profile** (from Query Router):
    - Direct kinship patterns detected in `query-router.ts` → `isDirectKinshipQuestion`
-   - Routes genealogy to `vectorWeight: 0.8, graphWeight: 0.2, k: 6` (fast)
-   - Skips graph search via adaptive fanout when `gw <= 0.25`
+   - Routes genealogy to `vectorWeight: 0.68, graphWeight: 0.17, bm25Weight: 0.15, k: 6` (fast)
+   - Keeps BM25 limited while still reducing graph fanout pressure
    - Result: genealogy queries drop from 6.6s → ~2s cold, correct Genesis verses for Joseph query
 
-2. **THEOLOGY weight bump + Christology keywords** (from Query Router US-009 refinement):
+2. **Intent-adaptive BM25 tuning**:
    - Added `"jesus"`, `"jésus"`, `"christ"`, `"messie"` to heuristic intent detection
-   - Adjusted `GENERAL: { vw: 0.8, gw: 0.2 }` (was 0.7/0.3)
-   - Ensures pure-vector queries stay <2s, irrelevant graph results skipped
+   - `GENERAL` and `GEOGRAPHY` boost BM25 to `0.4`
+   - `GENEALOGY` reduces BM25 to `0.15`
+   - `THEOLOGY` uses balanced BM25 at `0.3`
 
 3. **Genealogy lexical boost** (`rerankByQueryOverlap`):
    - If query looks genealogical, re-rank results by token overlap with query

--- a/docs/meilisearch-operations.md
+++ b/docs/meilisearch-operations.md
@@ -1,0 +1,70 @@
+# Meilisearch Operations Guide
+
+## Overview
+This guide covers operational procedures for the BM25 Meilisearch layer used by hybrid retrieval.
+
+## Service health checks
+- HTTP health endpoint: GET /health
+- Compose healthcheck is configured in services/compose.yml
+- App-level check: ensureMeilisearchIndexes + checkMeilisearchHealth in search-engine/src/lib/meilisearch-client.ts
+
+## Reindexing
+1. Start services:
+   - docker compose -f services/compose.yml up -d
+2. Run full reindex:
+   - cd search-engine
+   - npm run reindex:meilisearch
+3. Validate document counts:
+   - verses_bm25 should contain ~31k+ verses
+   - entities_bm25 should contain extracted entities and aliases
+
+## Scheduled reindex recommendation
+- Trigger full reindex after:
+  - processed_bible.json updates
+  - raw_graph.enrich.json updates
+  - production deployments with data migrations
+- Suggested cadence:
+  - nightly in staging
+  - release-triggered in production
+
+## Backup and restore
+- Data volume: meilisearch-data in services/compose.yml
+- Backup approach:
+  - stop writes
+  - snapshot meilisearch-data volume
+- Restore approach:
+  - restore volume snapshot
+  - rerun npm run reindex:meilisearch for consistency if needed
+
+## Capacity and growth
+- Expected current index size: ~100-200MB combined
+- Growth drivers:
+  - additional Bible versions
+  - entity alias expansion
+  - extra searchable attributes
+- Monitor:
+  - disk usage of meilisearch-data volume
+  - p95 latency of BM25 and fused hybrid requests
+
+## Failure handling and recovery
+- Application graceful degradation:
+  - BM25 errors are caught; retrieval falls back to vector+graph.
+  - Circuit breaker disables BM25 for 5 minutes after 3 consecutive failures.
+- Manual emergency toggle:
+  - set SKIP_MEILISEARCH=true
+- Recovery steps:
+  1. check /health
+  2. inspect container logs
+  3. verify API key and URL env vars
+  4. run reindex if index corruption suspected
+
+## Common troubleshooting
+- Symptom: BM25 returns empty hits
+  - Confirm indexes exist (verses_bm25, entities_bm25)
+  - Confirm documents were indexed
+- Symptom: connection refused
+  - Verify compose service is up and port 7700 is reachable
+- Symptom: unauthorized
+  - Verify MEILISEARCH_API_KEY matches configured master key
+- Symptom: stale lexical results
+  - rerun npm run reindex:meilisearch

--- a/docs/release-notes-hybrid-bm25.md
+++ b/docs/release-notes-hybrid-bm25.md
@@ -1,0 +1,36 @@
+# Release Notes: Hybrid Retrieval with BM25
+
+## Summary
+This release introduces a three-way hybrid retriever that fuses:
+- Vector search (DocumentDB)
+- Graph search (entity relations)
+- BM25 full-text search (Meilisearch)
+
+## Highlights
+- Added Meilisearch infrastructure and index bootstrap scripts
+- Added indexing scripts for verses and entities
+- Implemented RRF-3 weighted fusion with normalized weights
+- Added adaptive bm25Weight tuning by query intent
+- Added grounded-answer API support for disableBM25 A/B testing
+- Added BM25 graceful degradation with circuit breaker fallback
+
+## Performance targets
+- BM25 query target: <100ms
+- Combined hybrid query target: <300ms
+- Hybrid + fusion p95 target: <350ms
+
+## API changes
+- No breaking changes
+- New optional request field:
+  - bm25Weight in hybrid and grounded-answer request contracts
+- New optional query parameter:
+  - disableBM25=true on grounded-answer endpoint
+
+## Migration
+- Run docker compose with Meilisearch service enabled
+- Execute npm run reindex:meilisearch after deploy
+- If Meilisearch is unavailable, the system automatically falls back to vector+graph
+
+## Rollback
+- Set SKIP_MEILISEARCH=true to disable BM25 without redeploying code
+- Keep existing vector+graph path active

--- a/search-engine/src/__tests__/benchmarks/hybrid-search.bench.ts
+++ b/search-engine/src/__tests__/benchmarks/hybrid-search.bench.ts
@@ -1,0 +1,34 @@
+import { bench, describe } from "vitest";
+import { getDb } from "@search/lib/mongodb";
+import { HybridRetriever } from "@search/lib/hybrid-retriever";
+
+const runBench = process.env.RUN_HYBRID_BENCH === "true";
+const describeBench = runBench ? describe : describe.skip;
+
+describeBench("benchmark: hybrid retrieval", () => {
+  let retriever: HybridRetriever;
+
+  bench("vector only baseline", async () => {
+    if (!retriever) {
+      retriever = new HybridRetriever(await getDb());
+    }
+
+    await retriever.retrieve("Abraham", 5, 1, 0, 0, undefined, 0);
+  });
+
+  bench("bm25 weighted retrieval", async () => {
+    if (!retriever) {
+      retriever = new HybridRetriever(await getDb());
+    }
+
+    await retriever.retrieve("Abraham", 5, 0.48, 0.12, 0, undefined, 0.4);
+  });
+
+  bench("3-way hybrid retrieval", async () => {
+    if (!retriever) {
+      retriever = new HybridRetriever(await getDb());
+    }
+
+    await retriever.retrieve("Abraham", 5, 0.48, 0.12, 0, undefined, 0.4);
+  });
+});

--- a/search-engine/src/__tests__/context-injection.test.ts
+++ b/search-engine/src/__tests__/context-injection.test.ts
@@ -35,6 +35,8 @@ describe("context-injection", () => {
     expect(context.text).toContain("PARENT_OF -> Manassé");
     expect(context.text).toContain("Yossef => Joseph");
     expect(context.references).toEqual(["Genèse 46:19"]);
+    expect(context.sourceReferences.hybrid).toEqual(["Genèse 46:19"]);
+    expect(context.sourceReferences.bm25).toEqual([]);
   });
 
   it("builds strict grounding prompt rules in French", () => {

--- a/search-engine/src/__tests__/grounded-answer.test.ts
+++ b/search-engine/src/__tests__/grounded-answer.test.ts
@@ -89,8 +89,8 @@ vi.mock("@search/lib/context-injection", () => ({
   generateGroundedAnswerStream: generateGroundedAnswerStreamMock,
 }));
 
-function buildRequest(body: object): NextRequest {
-  return new NextRequest("http://localhost:3000/api/grounded-answer", {
+function buildRequest(body: object, url = "http://localhost:3000/api/grounded-answer"): NextRequest {
+  return new NextRequest(url, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
@@ -156,6 +156,27 @@ describe("POST /api/grounded-answer", () => {
     const json = await res.json();
     expect(json.metadata.source).toBe("retrieved-context");
     expect(json.metadata.retrieval).toBeTruthy();
+  });
+
+  it("disables BM25 when disableBM25 query param is true", async () => {
+    const POST = await getPOST();
+    const res = await POST(
+      buildRequest(
+        { query: "Qui est le fils de Joseph ?" },
+        "http://localhost:3000/api/grounded-answer?disableBM25=true"
+      )
+    );
+
+    expect(res.status).toBe(200);
+    expect(retrieveMock).toHaveBeenCalledWith(
+      "Qui est le fils de Joseph ?",
+      6,
+      0.8,
+      0.2,
+      0,
+      undefined,
+      0
+    );
   });
 
   it("returns uncertain answer for out-of-domain query", async () => {

--- a/search-engine/src/__tests__/hybrid-search.test.ts
+++ b/search-engine/src/__tests__/hybrid-search.test.ts
@@ -172,6 +172,7 @@ describe("POST /api/hybrid-search", () => {
       latencyMs: 0,
       filters: undefined,
       k: 5,
+      bm25Weight: 0,
     });
   });
 

--- a/search-engine/src/__tests__/integration/hybrid-search.test.ts
+++ b/search-engine/src/__tests__/integration/hybrid-search.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+const runLive = process.env.RUN_LIVE_HYBRID_TESTS === "true";
+const describeLive = runLive ? describe : describe.skip;
+
+async function getLiveDeps() {
+  const [{ getDb }, { HybridRetriever }, { ensureMeilisearchIndexes }] = await Promise.all([
+    import("@search/lib/mongodb"),
+    import("@search/lib/hybrid-retriever"),
+    import("@search/lib/meilisearch-client"),
+  ]);
+
+  return { getDb, HybridRetriever, ensureMeilisearchIndexes };
+}
+
+describeLive("integration: hybrid retriever with mongodb + meilisearch", () => {
+  it("returns fused results from vector/graph/bm25 without breaking schema", async () => {
+    const { getDb, HybridRetriever, ensureMeilisearchIndexes } = await getLiveDeps();
+    const db = await getDb();
+    await ensureMeilisearchIndexes();
+
+    const retriever = new HybridRetriever(db);
+    const result = await retriever.retrieve(
+      "Abraham en Egypte",
+      6,
+      0.48,
+      0.12,
+      0,
+      { book: "Genèse", testament: "Ancien Testament" },
+      0.4
+    );
+
+    expect(result.verses.length).toBeGreaterThan(0);
+    expect(result.metadata.vectorWeight + result.metadata.graphWeight + result.metadata.bm25Weight).toBe(1);
+    expect(result.metadata.totalBM25Results).toBeGreaterThanOrEqual(0);
+  });
+
+  it("supports disableBM25 scenario while preserving retrieval", async () => {
+    const { getDb, HybridRetriever } = await getLiveDeps();
+    const db = await getDb();
+    const retriever = new HybridRetriever(db);
+
+    const withBm25 = await retriever.retrieve("Jésus", 5, 0.63, 0.07, 0, undefined, 0.3);
+    const withoutBm25 = await retriever.retrieve("Jésus", 5, 0.63, 0.07, 0, undefined, 0);
+
+    expect(withoutBm25.verses.length).toBeGreaterThan(0);
+    expect(withoutBm25.metadata.totalBM25Results).toBe(0);
+    expect(withBm25.verses.length).toBeGreaterThan(0);
+  });
+});

--- a/search-engine/src/__tests__/query-router.test.ts
+++ b/search-engine/src/__tests__/query-router.test.ts
@@ -33,4 +33,25 @@ describe("query-router French heuristics", () => {
     expect(result.graphWeight).toBe(0.3);
     expect(result.bm25Weight).toBe(0.4);
   });
+
+  it("applies chronology bm25 tuning", async () => {
+    const result = await routeQuery({ query: "Quand David regna-t-il ?" });
+
+    expect(result.intent).toBe("CHRONOLOGY");
+    expect(result.bm25Weight).toBe(0.25);
+  });
+
+  it("applies theology bm25 tuning", async () => {
+    const result = await routeQuery({ query: "Que dit la Bible sur la grace ?" });
+
+    expect(result.intent).toBe("THEOLOGY");
+    expect(result.bm25Weight).toBe(0.3);
+  });
+
+  it("applies general bm25 tuning", async () => {
+    const result = await routeQuery({ query: "Parle-moi d'Abraham" });
+
+    expect(result.intent).toBe("GENERAL");
+    expect(result.bm25Weight).toBe(0.4);
+  });
 });

--- a/search-engine/src/app/api/grounded-answer/route.ts
+++ b/search-engine/src/app/api/grounded-answer/route.ts
@@ -38,9 +38,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     k,
     vectorWeight,
     graphWeight,
+    bm25Weight,
     filters,
     minScore = 0.0,
   } = body;
+
+  const disableBM25 = req.nextUrl.searchParams.get("disableBM25") === "true";
 
   if (!query || typeof query !== "string" || query.trim().length === 0) {
     return NextResponse.json(
@@ -73,6 +76,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           k,
           vectorWeight,
           graphWeight,
+          bm25Weight,
           filters,
         },
       });
@@ -85,7 +89,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         routing.vectorWeight,
         routing.graphWeight,
         minScore,
-        routing.filters
+        routing.filters,
+        disableBM25 ? 0 : routing.bm25Weight
       );
 
       verses = retrievalResult.verses;
@@ -100,6 +105,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           latencyMs: routing.latencyMs,
           filters: routing.filters,
           k: routing.k,
+          bm25Weight: disableBM25 ? 0 : routing.bm25Weight,
+          bm25Disabled: disableBM25,
         },
       };
 

--- a/search-engine/src/app/api/hybrid-search/route.ts
+++ b/search-engine/src/app/api/hybrid-search/route.ts
@@ -109,6 +109,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           latencyMs: routing.latencyMs,
           filters: routing.filters,
           k: routing.k,
+          bm25Weight: routing.bm25Weight,
         },
       },
     };

--- a/search-engine/src/lib/__tests__/hybrid-retriever.test.ts
+++ b/search-engine/src/lib/__tests__/hybrid-retriever.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("openai", () => {
+  return {
+    default: class OpenAI {
+      embeddings = {
+        create: vi.fn(),
+      };
+    },
+  };
+});
+
+async function getHybridRetrieverClass() {
+  const mod = await import("@search/lib/hybrid-retriever");
+  return mod.HybridRetriever;
+}
+
+async function createRetriever() {
+  const HybridRetriever = await getHybridRetrieverClass();
+  const db = {
+    collection: vi.fn().mockReturnValue({
+      find: vi.fn(),
+      aggregate: vi.fn(),
+    }),
+  };
+
+  return new HybridRetriever(db as never);
+}
+
+describe("hybrid-retriever.retrieve", () => {
+  it("normalizes three-way weights when input sum is not 1.0", async () => {
+    const retriever = await createRetriever();
+
+    vi.spyOn(retriever, "vectorSearch").mockResolvedValue([
+      {
+        id: "b.GEN.1.1",
+        reference: "Genèse 1:1",
+        text: "Au commencement...",
+        score: 1,
+        source: "vector",
+        entitySlugs: ["abraham"],
+      },
+    ] as never);
+    vi.spyOn(retriever, "graphSearch").mockResolvedValue([]);
+    vi.spyOn(retriever, "bm25Search").mockResolvedValue([]);
+    vi.spyOn(retriever, "augmentWithEntityFacts").mockResolvedValue([]);
+
+    const result = await retriever.retrieve("creation", 5, 2, 1, 0, undefined, 0.5);
+    const total = result.metadata.vectorWeight + result.metadata.graphWeight + result.metadata.bm25Weight;
+
+    expect(total).toBe(1);
+    expect(result.metadata.vectorWeight).toBeGreaterThan(0);
+    expect(result.metadata.graphWeight).toBeGreaterThan(0);
+    expect(result.metadata.bm25Weight).toBeGreaterThan(0);
+  });
+
+  it("fuses vector, graph, and bm25 results with deduplication", async () => {
+    const retriever = await createRetriever();
+
+    vi.spyOn(retriever, "vectorSearch").mockResolvedValue([
+      {
+        id: "b.GEN.1.1",
+        reference: "Genèse 1:1",
+        text: "Au commencement...",
+        score: 1,
+        source: "vector",
+        entitySlugs: ["abraham"],
+      },
+    ] as never);
+
+    vi.spyOn(retriever, "graphSearch").mockResolvedValue([
+      {
+        id: "b.GEN.1.1",
+        reference: "Genèse 1:1",
+        text: "Au commencement...",
+        score: 0.9,
+        source: "graph",
+        entitySlugs: ["abraham"],
+      },
+      {
+        id: "b.GEN.1.2",
+        reference: "Genèse 1:2",
+        text: "La terre était informe...",
+        score: 0.7,
+        source: "graph",
+        entitySlugs: ["terre"],
+      },
+    ] as never);
+
+    vi.spyOn(retriever, "bm25Search").mockResolvedValue([
+      {
+        id: "b.GEN.1.2",
+        reference: "Genèse 1:2",
+        text: "La terre était informe...",
+        score: 1,
+        source: "bm25",
+        entitySlugs: ["terre"],
+      },
+    ] as never);
+
+    vi.spyOn(retriever, "augmentWithEntityFacts").mockResolvedValue([]);
+
+    const result = await retriever.retrieve("terre informe", 5, 0.5, 0.2, 0, undefined, 0.3);
+
+    expect(result.verses.length).toBe(2);
+    expect(result.verses.every((v) => v.source === "hybrid")).toBe(true);
+    expect(result.metadata.totalVectorResults).toBe(1);
+    expect(result.metadata.totalGraphResults).toBe(2);
+    expect(result.metadata.totalBM25Results).toBe(1);
+  });
+
+  it("supports graceful degradation when bm25 returns no hits", async () => {
+    const retriever = await createRetriever();
+
+    vi.spyOn(retriever, "vectorSearch").mockResolvedValue([
+      {
+        id: "b.GEN.1.1",
+        reference: "Genèse 1:1",
+        text: "Au commencement...",
+        score: 1,
+        source: "vector",
+        entitySlugs: ["abraham"],
+      },
+    ] as never);
+    vi.spyOn(retriever, "graphSearch").mockResolvedValue([]);
+    vi.spyOn(retriever, "bm25Search").mockResolvedValue([]);
+    vi.spyOn(retriever, "augmentWithEntityFacts").mockResolvedValue([]);
+
+    const result = await retriever.retrieve("creation", 5, 0.7, 0.2, 0, undefined, 0.1);
+
+    expect(result.verses.length).toBeGreaterThan(0);
+    expect(result.metadata.totalBM25Results).toBe(0);
+  });
+});

--- a/search-engine/src/lib/context-injection.ts
+++ b/search-engine/src/lib/context-injection.ts
@@ -15,6 +15,7 @@ function createCopilotClient(): OpenAI {
 const DEFAULT_MODEL = process.env.GROUNDED_ANSWER_MODEL ?? "gpt-4o-mini";
 const UNKNOWN_RESPONSE = "Je ne sais pas d'après les Écritures fournies.";
 const PROMPT_VERSION = "us-010.v2";
+const CONTEXT_DEBUG = process.env.CONTEXT_INJECTION_DEBUG === "true";
 
 const OUT_OF_DOMAIN_MARKERS = [
   "elon musk", "einstein", "napoleon", "hitler", "newton", "shakespeare",
@@ -30,6 +31,12 @@ export function isOutOfDomainQuery(query: string): boolean {
 export interface AssembledContext {
   text: string;
   references: string[];
+  sourceReferences: {
+    vector: string[];
+    graph: string[];
+    bm25: string[];
+    hybrid: string[];
+  };
 }
 
 export interface GroundedAnswerResult {
@@ -65,7 +72,17 @@ function canonicalizeRelationType(rawType: string): string {
 }
 
 export function assembleHybridContext(verses: VerseResult[], entityFacts: EntityFact[]): AssembledContext {
-  const verseLines = verses.map((verse) => `[${verse.reference}] ${verse.text}`);
+  const sourceReferences = {
+    vector: verses.filter((verse) => verse.source === "vector").map((verse) => verse.reference),
+    graph: verses.filter((verse) => verse.source === "graph").map((verse) => verse.reference),
+    bm25: verses.filter((verse) => verse.source === "bm25").map((verse) => verse.reference),
+    hybrid: verses.filter((verse) => verse.source === "hybrid").map((verse) => verse.reference),
+  };
+
+  const verseLines = verses.map((verse) => {
+    const debugPrefix = CONTEXT_DEBUG && verse.source === "bm25" ? "[BM25 match:] " : "";
+    return `[${verse.reference}] ${debugPrefix}${verse.text}`;
+  });
   const aliasLines: string[] = [];
 
   const entityLines = entityFacts.map((entity) => {
@@ -107,6 +124,7 @@ export function assembleHybridContext(verses: VerseResult[], entityFacts: Entity
   return {
     text,
     references: verses.map((verse) => verse.reference),
+    sourceReferences,
   };
 }
 

--- a/search-engine/src/types/grounded-answer.ts
+++ b/search-engine/src/types/grounded-answer.ts
@@ -11,6 +11,7 @@ export interface GroundedAnswerRequest {
   k?: number;
   vectorWeight?: number;
   graphWeight?: number;
+  bm25Weight?: number;
   filters?: HybridFilters;
   minScore?: number;
 }

--- a/search-engine/src/types/hybrid.ts
+++ b/search-engine/src/types/hybrid.ts
@@ -60,6 +60,8 @@ export interface HybridSearchResponse {
       latencyMs: number;
       filters?: HybridFilters;
       k: number;
+      bm25Weight?: number;
+      bm25Disabled?: boolean;
     };
   };
 }


### PR DESCRIPTION
Implements Phase 6 documentation and rollout artifacts on top of Phase 5.

Scope:
- Update architecture docs for Meilisearch + RRF-3
- Update hybrid retriever docs for BM25 scoring/tuning/degradation
- Add operations runbook for Meilisearch
- Update README and add release note document

Key files:
- docs/architecture-rag-graph-router.md
- docs/hybrid-retriever.md
- docs/meilisearch-operations.md
- docs/release-notes-hybrid-bm25.md
- README.md

Refs #52