### PR TITLE
feat(search-engine): add Phase 1 LLM client factory scaffold

### DIFF
--- a/search-engine/src/__tests__/llm-factory.test.ts
+++ b/search-engine/src/__tests__/llm-factory.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearLlmProviderRegistry,
+  createLlmClient,
+  registerLlmProvider,
+  resolveAndValidateLlmClientOptions,
+} from "@search/lib/llm/factory";
+import type { LlmClient, RegisteredLlmProvider } from "@search/lib/llm/types";
+
+const envSnapshot = {
+  GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+  OLLAMA_BASE_URL: process.env.OLLAMA_BASE_URL,
+  LLM_DEFAULT_PROVIDER: process.env.LLM_DEFAULT_PROVIDER,
+  QUERY_ROUTER_MODEL: process.env.QUERY_ROUTER_MODEL,
+  GROUNDED_ANSWER_MODEL: process.env.GROUNDED_ANSWER_MODEL,
+  COPILOTE_MODEL: process.env.COPILOTE_MODEL,
+  COPILOT_MODEL: process.env.COPILOT_MODEL,
+};
+
+function createMockProvider(name: RegisteredLlmProvider["name"]): RegisteredLlmProvider {
+  const client: LlmClient = {
+    async complete(request) {
+      return {
+        content: request.messages.map((message) => message.content).join(" "),
+        model: request.model ?? "mock-model",
+        provider: name,
+      };
+    },
+  };
+
+  return {
+    name,
+    displayName: `${name} mock`,
+    capabilities: {
+      supportsStreaming: true,
+      supportsJsonMode: true,
+    },
+    createClient: () => client,
+  };
+}
+
+describe("llm factory", () => {
+  beforeEach(() => {
+    clearLlmProviderRegistry();
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.OLLAMA_BASE_URL;
+    delete process.env.LLM_DEFAULT_PROVIDER;
+    delete process.env.QUERY_ROUTER_MODEL;
+    delete process.env.GROUNDED_ANSWER_MODEL;
+    delete process.env.COPILOTE_MODEL;
+    delete process.env.COPILOT_MODEL;
+  });
+
+  afterEach(() => {
+    clearLlmProviderRegistry();
+    process.env.GITHUB_TOKEN = envSnapshot.GITHUB_TOKEN;
+    process.env.OPENAI_API_KEY = envSnapshot.OPENAI_API_KEY;
+    process.env.GEMINI_API_KEY = envSnapshot.GEMINI_API_KEY;
+    process.env.OLLAMA_BASE_URL = envSnapshot.OLLAMA_BASE_URL;
+    process.env.LLM_DEFAULT_PROVIDER = envSnapshot.LLM_DEFAULT_PROVIDER;
+    process.env.QUERY_ROUTER_MODEL = envSnapshot.QUERY_ROUTER_MODEL;
+    process.env.GROUNDED_ANSWER_MODEL = envSnapshot.GROUNDED_ANSWER_MODEL;
+    process.env.COPILOTE_MODEL = envSnapshot.COPILOTE_MODEL;
+    process.env.COPILOT_MODEL = envSnapshot.COPILOT_MODEL;
+  });
+
+  it("resolves legacy extraction model aliases", () => {
+    process.env.GITHUB_TOKEN = "github-token";
+    process.env.COPILOTE_MODEL = "gpt-4o-mini-custom";
+
+    const resolved = resolveAndValidateLlmClientOptions({
+      purpose: "extraction",
+      provider: "copilot",
+    });
+
+    expect(resolved.model).toBe("gpt-4o-mini-custom");
+    expect(resolved.secrets.githubToken).toBe("github-token");
+  });
+
+  it("uses purpose-specific legacy router model env", () => {
+    process.env.OPENAI_API_KEY = "openai-key";
+    process.env.QUERY_ROUTER_MODEL = "gpt-4.1-mini";
+
+    const resolved = resolveAndValidateLlmClientOptions({
+      purpose: "router",
+      provider: "openai",
+    });
+
+    expect(resolved.model).toBe("gpt-4.1-mini");
+  });
+
+  it("throws when required copilot secret is missing", () => {
+    expect(() =>
+      resolveAndValidateLlmClientOptions({
+        purpose: "chat",
+        provider: "copilot",
+      })
+    ).toThrow("Missing required secret githubToken for provider copilot.");
+  });
+
+  it("creates a client from the registered provider", async () => {
+    process.env.OPENAI_API_KEY = "openai-key";
+    registerLlmProvider(createMockProvider("openai"));
+
+    const client = await createLlmClient({
+      purpose: "chat",
+      provider: "openai",
+      model: "gpt-4o-mini",
+    });
+
+    const response = await client.complete({
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(response.provider).toBe("openai");
+    expect(response.content).toBe("hello");
+  });
+
+  it("selects the default provider from env when provider is omitted", async () => {
+    process.env.GEMINI_API_KEY = "gemini-key";
+    process.env.LLM_DEFAULT_PROVIDER = "gemini";
+    registerLlmProvider(createMockProvider("gemini"));
+
+    const client = await createLlmClient({
+      purpose: "chat",
+      model: "gemini-2.0-flash",
+    });
+
+    const response = await client.complete({
+      messages: [{ role: "user", content: "bonjour" }],
+    });
+
+    expect(response.provider).toBe("gemini");
+  });
+
+  it("throws when no provider adapter is registered", async () => {
+    process.env.GITHUB_TOKEN = "github-token";
+
+    await expect(
+      createLlmClient({
+        purpose: "chat",
+        provider: "copilot",
+      })
+    ).rejects.toThrow("No LLM provider registered for copilot.");
+  });
+});

--- a/search-engine/src/__tests__/llm-factory.test.ts
+++ b/search-engine/src/__tests__/llm-factory.test.ts
@@ -19,6 +19,15 @@ const envSnapshot = {
   COPILOT_MODEL: process.env.COPILOT_MODEL,
 };
 
+function restoreEnv(name: keyof typeof envSnapshot, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
 function createMockProvider(name: RegisteredLlmProvider["name"]): RegisteredLlmProvider {
   const client: LlmClient = {
     async complete(request) {
@@ -57,15 +66,15 @@ describe("llm factory", () => {
 
   afterEach(() => {
     clearLlmProviderRegistry();
-    process.env.GITHUB_TOKEN = envSnapshot.GITHUB_TOKEN;
-    process.env.OPENAI_API_KEY = envSnapshot.OPENAI_API_KEY;
-    process.env.GEMINI_API_KEY = envSnapshot.GEMINI_API_KEY;
-    process.env.OLLAMA_BASE_URL = envSnapshot.OLLAMA_BASE_URL;
-    process.env.LLM_DEFAULT_PROVIDER = envSnapshot.LLM_DEFAULT_PROVIDER;
-    process.env.QUERY_ROUTER_MODEL = envSnapshot.QUERY_ROUTER_MODEL;
-    process.env.GROUNDED_ANSWER_MODEL = envSnapshot.GROUNDED_ANSWER_MODEL;
-    process.env.COPILOTE_MODEL = envSnapshot.COPILOTE_MODEL;
-    process.env.COPILOT_MODEL = envSnapshot.COPILOT_MODEL;
+    restoreEnv("GITHUB_TOKEN", envSnapshot.GITHUB_TOKEN);
+    restoreEnv("OPENAI_API_KEY", envSnapshot.OPENAI_API_KEY);
+    restoreEnv("GEMINI_API_KEY", envSnapshot.GEMINI_API_KEY);
+    restoreEnv("OLLAMA_BASE_URL", envSnapshot.OLLAMA_BASE_URL);
+    restoreEnv("LLM_DEFAULT_PROVIDER", envSnapshot.LLM_DEFAULT_PROVIDER);
+    restoreEnv("QUERY_ROUTER_MODEL", envSnapshot.QUERY_ROUTER_MODEL);
+    restoreEnv("GROUNDED_ANSWER_MODEL", envSnapshot.GROUNDED_ANSWER_MODEL);
+    restoreEnv("COPILOTE_MODEL", envSnapshot.COPILOTE_MODEL);
+    restoreEnv("COPILOT_MODEL", envSnapshot.COPILOT_MODEL);
   });
 
   it("resolves legacy extraction model aliases", () => {
@@ -135,6 +144,22 @@ describe("llm factory", () => {
     });
 
     expect(response.provider).toBe("gemini");
+  });
+
+  it("infers the provider from explicit secrets when provider is omitted", async () => {
+    registerLlmProvider(createMockProvider("openai"));
+
+    const client = await createLlmClient({
+      purpose: "chat",
+      secrets: { openAIApiKey: "openai-key" },
+      model: "gpt-4o-mini",
+    });
+
+    const response = await client.complete({
+      messages: [{ role: "user", content: "salut" }],
+    });
+
+    expect(response.provider).toBe("openai");
   });
 
   it("throws when no provider adapter is registered", async () => {

--- a/search-engine/src/lib/llm/env.ts
+++ b/search-engine/src/lib/llm/env.ts
@@ -1,0 +1,110 @@
+import type {
+  LlmClientOptions,
+  LlmProviderName,
+  LlmPurpose,
+  LlmSecrets,
+  ResolvedLlmClientOptions,
+} from "@search/lib/llm/types";
+
+const PURPOSE_ENV_SUFFIX: Record<LlmPurpose, string> = {
+  chat: "CHAT",
+  router: "ROUTER",
+  "grounded-answer": "GROUNDED_ANSWER",
+  extraction: "EXTRACTION",
+};
+
+const PURPOSE_MODEL_ENV_KEYS: Record<LlmPurpose, string[]> = {
+  chat: ["LLM_CHAT_MODEL", "GROUNDED_ANSWER_MODEL"],
+  router: ["LLM_ROUTER_MODEL", "QUERY_ROUTER_MODEL"],
+  "grounded-answer": ["LLM_GROUNDED_ANSWER_MODEL", "GROUNDED_ANSWER_MODEL"],
+  extraction: ["LLM_EXTRACTION_MODEL", "COPILOT_MODEL", "COPILOTE_MODEL"],
+};
+
+const PROVIDER_DEFAULT_MODELS: Record<LlmProviderName, string> = {
+  copilot: "gpt-4o-mini",
+  openai: "gpt-4o-mini",
+  gemini: "gemini-2.0-flash",
+  ollama: "llama3.2",
+};
+
+function parseProviderName(value?: string | null): LlmProviderName | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (normalized === "copilot" || normalized === "openai" || normalized === "gemini" || normalized === "ollama") {
+    return normalized;
+  }
+  return undefined;
+}
+
+function readFirstEnv(keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function resolveProviderFromEnv(purpose: LlmPurpose): LlmProviderName | undefined {
+  const suffix = PURPOSE_ENV_SUFFIX[purpose];
+  return (
+    parseProviderName(process.env[`LLM_${suffix}_PROVIDER`]) ??
+    parseProviderName(process.env.LLM_DEFAULT_PROVIDER)
+  );
+}
+
+function inferProviderFromSecrets(): LlmProviderName | undefined {
+  if (process.env.GITHUB_TOKEN?.trim()) return "copilot";
+  if (process.env.OPENAI_API_KEY?.trim()) return "openai";
+  if (process.env.GEMINI_API_KEY?.trim()) return "gemini";
+  if (process.env.OLLAMA_BASE_URL?.trim() || process.env.OLLAMA_MODEL?.trim()) return "ollama";
+  return undefined;
+}
+
+export function resolveLlmProvider(options: LlmClientOptions): LlmProviderName {
+  return options.provider ?? resolveProviderFromEnv(options.purpose) ?? inferProviderFromSecrets() ?? "copilot";
+}
+
+export function resolveLlmSecrets(provider: LlmProviderName, overrides?: LlmSecrets): LlmSecrets {
+  return {
+    githubToken: overrides?.githubToken ?? process.env.GITHUB_TOKEN,
+    openAIApiKey: overrides?.openAIApiKey ?? overrides?.apiKey ?? process.env.OPENAI_API_KEY,
+    geminiApiKey: overrides?.geminiApiKey ?? overrides?.apiKey ?? process.env.GEMINI_API_KEY,
+    ollamaBaseUrl:
+      overrides?.ollamaBaseUrl ?? overrides?.baseUrl ?? process.env.OLLAMA_BASE_URL ?? "http://localhost:11434/v1",
+    apiKey: overrides?.apiKey,
+    baseUrl: overrides?.baseUrl,
+  };
+}
+
+export function resolveLlmModel(provider: LlmProviderName, purpose: LlmPurpose, override?: string): string {
+  if (override?.trim()) return override.trim();
+
+  const providerSpecific = readFirstEnv([
+    `LLM_${PURPOSE_ENV_SUFFIX[purpose]}_${provider.toUpperCase()}_MODEL`,
+    `${provider.toUpperCase()}_${PURPOSE_ENV_SUFFIX[purpose]}_MODEL`,
+  ]);
+  if (providerSpecific) return providerSpecific;
+
+  const purposeSpecific = readFirstEnv(PURPOSE_MODEL_ENV_KEYS[purpose]);
+  if (purposeSpecific) return purposeSpecific;
+
+  const genericProvider = readFirstEnv([
+    `${provider.toUpperCase()}_MODEL`,
+    provider === "copilot" ? "COPILOTE_MODEL" : "",
+  ].filter(Boolean));
+  if (genericProvider) return genericProvider;
+
+  return PROVIDER_DEFAULT_MODELS[provider];
+}
+
+export function resolveLlmClientOptions(options: LlmClientOptions): ResolvedLlmClientOptions {
+  const provider = resolveLlmProvider(options);
+  return {
+    provider,
+    purpose: options.purpose,
+    model: resolveLlmModel(provider, options.purpose, options.model),
+    secrets: resolveLlmSecrets(provider, options.secrets),
+    timeoutMs: options.timeoutMs,
+    maxRetries: options.maxRetries,
+  };
+}

--- a/search-engine/src/lib/llm/env.ts
+++ b/search-engine/src/lib/llm/env.ts
@@ -52,16 +52,32 @@ function resolveProviderFromEnv(purpose: LlmPurpose): LlmProviderName | undefine
   );
 }
 
-function inferProviderFromSecrets(): LlmProviderName | undefined {
-  if (process.env.GITHUB_TOKEN?.trim()) return "copilot";
-  if (process.env.OPENAI_API_KEY?.trim()) return "openai";
-  if (process.env.GEMINI_API_KEY?.trim()) return "gemini";
-  if (process.env.OLLAMA_BASE_URL?.trim() || process.env.OLLAMA_MODEL?.trim()) return "ollama";
+function inferProviderFromSecrets(overrides?: LlmSecrets): LlmProviderName | undefined {
+  if (overrides?.githubToken?.trim() || process.env.GITHUB_TOKEN?.trim()) return "copilot";
+  if (overrides?.openAIApiKey?.trim() || overrides?.apiKey?.trim() || process.env.OPENAI_API_KEY?.trim()) {
+    return "openai";
+  }
+  if (overrides?.geminiApiKey?.trim() || overrides?.apiKey?.trim() || process.env.GEMINI_API_KEY?.trim()) {
+    return "gemini";
+  }
+  if (
+    overrides?.ollamaBaseUrl?.trim() ||
+    overrides?.baseUrl?.trim() ||
+    process.env.OLLAMA_BASE_URL?.trim() ||
+    process.env.OLLAMA_MODEL?.trim()
+  ) {
+    return "ollama";
+  }
   return undefined;
 }
 
 export function resolveLlmProvider(options: LlmClientOptions): LlmProviderName {
-  return options.provider ?? resolveProviderFromEnv(options.purpose) ?? inferProviderFromSecrets() ?? "copilot";
+  return (
+    options.provider ??
+    resolveProviderFromEnv(options.purpose) ??
+    inferProviderFromSecrets(options.secrets) ??
+    "copilot"
+  );
 }
 
 export function resolveLlmSecrets(provider: LlmProviderName, overrides?: LlmSecrets): LlmSecrets {

--- a/search-engine/src/lib/llm/factory.ts
+++ b/search-engine/src/lib/llm/factory.ts
@@ -1,0 +1,78 @@
+import { resolveLlmClientOptions } from "@search/lib/llm/env";
+import type {
+  LlmClient,
+  LlmClientOptions,
+  LlmProviderName,
+  LlmSecrets,
+  RegisteredLlmProvider,
+  ResolvedLlmClientOptions,
+} from "@search/lib/llm/types";
+
+const providerRegistry = new Map<LlmProviderName, RegisteredLlmProvider>();
+
+function requireSecret(value: string | undefined, name: string, provider: LlmProviderName): void {
+  if (!value?.trim()) {
+    throw new Error(`Missing required secret ${name} for provider ${provider}.`);
+  }
+}
+
+export function validateProviderSecrets(provider: LlmProviderName, secrets: LlmSecrets): void {
+  switch (provider) {
+    case "copilot":
+      requireSecret(secrets.githubToken, "githubToken", provider);
+      break;
+    case "openai":
+      requireSecret(secrets.openAIApiKey ?? secrets.apiKey, "openAIApiKey", provider);
+      break;
+    case "gemini":
+      requireSecret(secrets.geminiApiKey ?? secrets.apiKey, "geminiApiKey", provider);
+      break;
+    case "ollama":
+      requireSecret(secrets.ollamaBaseUrl ?? secrets.baseUrl, "ollamaBaseUrl", provider);
+      break;
+  }
+}
+
+export function registerLlmProvider(provider: RegisteredLlmProvider, options?: { overwrite?: boolean }): void {
+  const existing = providerRegistry.get(provider.name);
+  if (existing && !options?.overwrite) {
+    throw new Error(`Provider ${provider.name} is already registered.`);
+  }
+  providerRegistry.set(provider.name, provider);
+}
+
+export function unregisterLlmProvider(name: LlmProviderName): void {
+  providerRegistry.delete(name);
+}
+
+export function clearLlmProviderRegistry(): void {
+  providerRegistry.clear();
+}
+
+export function getRegisteredLlmProvider(name: LlmProviderName): RegisteredLlmProvider | undefined {
+  return providerRegistry.get(name);
+}
+
+export function listRegisteredLlmProviders(): RegisteredLlmProvider[] {
+  return Array.from(providerRegistry.values());
+}
+
+export function resolveAndValidateLlmClientOptions(options: LlmClientOptions): ResolvedLlmClientOptions {
+  const resolved = resolveLlmClientOptions(options);
+  validateProviderSecrets(resolved.provider, resolved.secrets);
+  return resolved;
+}
+
+export async function createLlmClient(options: LlmClientOptions): Promise<LlmClient> {
+  const resolved = resolveAndValidateLlmClientOptions(options);
+  const provider = providerRegistry.get(resolved.provider);
+
+  if (!provider) {
+    throw new Error(`No LLM provider registered for ${resolved.provider}.`);
+  }
+
+  (provider.validateSecrets ?? ((secrets) => validateProviderSecrets(resolved.provider, secrets)))(
+    resolved.secrets
+  );
+  return provider.createClient(resolved);
+}

--- a/search-engine/src/lib/llm/types.ts
+++ b/search-engine/src/lib/llm/types.ts
@@ -1,0 +1,77 @@
+export type LlmProviderName = "copilot" | "openai" | "gemini" | "ollama";
+
+export type LlmPurpose = "chat" | "router" | "grounded-answer" | "extraction";
+
+export type LlmRole = "system" | "user" | "assistant";
+
+export interface LlmMessage {
+  role: LlmRole;
+  content: string;
+}
+
+export interface LlmCapabilities {
+  supportsStreaming: boolean;
+  supportsJsonMode: boolean;
+  defaultTimeoutMs?: number;
+  maxContextTokens?: number;
+  rateLimitSensitivity?: "low" | "medium" | "high";
+}
+
+export interface LlmSecrets {
+  githubToken?: string;
+  openAIApiKey?: string;
+  geminiApiKey?: string;
+  ollamaBaseUrl?: string;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export interface LlmClientOptions {
+  provider?: LlmProviderName;
+  purpose: LlmPurpose;
+  model?: string;
+  secrets?: LlmSecrets;
+  timeoutMs?: number;
+  maxRetries?: number;
+}
+
+export interface ResolvedLlmClientOptions {
+  provider: LlmProviderName;
+  purpose: LlmPurpose;
+  model: string;
+  secrets: LlmSecrets;
+  timeoutMs?: number;
+  maxRetries?: number;
+}
+
+export interface LlmCompletionRequest {
+  model?: string;
+  messages: LlmMessage[];
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export interface LlmCompletionResponse {
+  content: string;
+  model: string;
+  provider: LlmProviderName;
+  raw?: unknown;
+}
+
+export interface LlmJsonRequest extends LlmCompletionRequest {
+  schemaName?: string;
+}
+
+export interface LlmClient {
+  complete(request: LlmCompletionRequest): Promise<LlmCompletionResponse>;
+  stream?(request: LlmCompletionRequest): AsyncIterable<string>;
+  completeJson?<T>(request: LlmJsonRequest): Promise<T>;
+}
+
+export interface RegisteredLlmProvider {
+  name: LlmProviderName;
+  displayName: string;
+  capabilities: LlmCapabilities;
+  validateSecrets?: (secrets: LlmSecrets) => void;
+  createClient: (options: ResolvedLlmClientOptions) => LlmClient | Promise<LlmClient>;
+}


### PR DESCRIPTION
## Summary
- add shared LLM provider, client, and request/response types for Copilot, OpenAI, Gemini, and Ollama
- add env-backed option resolution for provider, model, and secrets with legacy compatibility such as `COPILOTE_MODEL`
- add a provider registry and factory entry point with secret validation
- add focused unit tests for provider selection, env resolution, and registry behavior

## Validation
- `npm run test:run -- src/__tests__/llm-factory.test.ts`

Closes #63