### PR TITLE
feat(search-engine): add LLM provider adapters

### DIFF
--- a/search-engine/src/__tests__/llm-providers.test.ts
+++ b/search-engine/src/__tests__/llm-providers.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import OpenAI from "openai";
+import { clearLlmProviderRegistry, createLlmClient, listRegisteredLlmProviders } from "@search/lib/llm/factory";
+import {
+  registerDefaultLlmProviders,
+  resetDefaultLlmProvidersRegistration,
+} from "@search/lib/llm/providers";
+
+const createMock = vi.fn();
+
+vi.mock("openai", () => {
+  const OpenAIMock = vi.fn(class MockOpenAI {
+    chat = {
+      completions: {
+        create: createMock,
+      },
+    };
+  });
+
+  return {
+    default: OpenAIMock,
+  };
+});
+
+describe("llm providers", () => {
+  const fetchMock = vi.fn();
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    clearLlmProviderRegistry();
+    resetDefaultLlmProvidersRegistration();
+    createMock.mockReset();
+    fetchMock.mockReset();
+    global.fetch = fetchMock as typeof fetch;
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.OLLAMA_BASE_URL;
+  });
+
+  afterEach(() => {
+    clearLlmProviderRegistry();
+    resetDefaultLlmProvidersRegistration();
+    global.fetch = originalFetch;
+  });
+
+  it("registers all default providers once", () => {
+    registerDefaultLlmProviders();
+    registerDefaultLlmProviders();
+
+    expect(listRegisteredLlmProviders().map((provider) => provider.name)).toEqual([
+      "copilot",
+      "openai",
+      "gemini",
+      "ollama",
+    ]);
+  });
+
+  it("creates a Copilot-backed client and issues a completion", async () => {
+    process.env.GITHUB_TOKEN = "github-token";
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: "copilot response" } }],
+    });
+    registerDefaultLlmProviders();
+
+    const client = await createLlmClient({
+      purpose: "chat",
+      provider: "copilot",
+      model: "gpt-4o-mini",
+    });
+
+    const response = await client.complete({
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(response.provider).toBe("copilot");
+    expect(response.content).toBe("copilot response");
+    expect(OpenAI).toHaveBeenCalled();
+  });
+
+  it("creates an OpenAI-backed client and parses JSON output", async () => {
+    process.env.OPENAI_API_KEY = "openai-key";
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: '{"ok":true}' } }],
+    });
+    registerDefaultLlmProviders();
+
+    const client = await createLlmClient({
+      purpose: "router",
+      provider: "openai",
+    });
+
+    await expect(
+      client.completeJson?.<{ ok: boolean }>({
+        messages: [{ role: "user", content: "json please" }],
+      })
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("creates an Ollama-backed client with the default local endpoint", async () => {
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: "ollama response" } }],
+    });
+    registerDefaultLlmProviders();
+
+    const client = await createLlmClient({
+      purpose: "chat",
+      provider: "ollama",
+      secrets: { ollamaBaseUrl: "http://localhost:11434/v1" },
+    });
+
+    const response = await client.complete({
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(response.provider).toBe("ollama");
+  });
+
+  it("creates a Gemini-backed client and issues a completion", async () => {
+    process.env.GEMINI_API_KEY = "gemini-key";
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: "gemini response" }] } }],
+      }),
+    });
+    registerDefaultLlmProviders();
+
+    const client = await createLlmClient({
+      purpose: "chat",
+      provider: "gemini",
+    });
+
+    const response = await client.complete({
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(response.provider).toBe("gemini");
+    expect(response.content).toBe("gemini response");
+  });
+});

--- a/search-engine/src/lib/llm/providers/gemini.ts
+++ b/search-engine/src/lib/llm/providers/gemini.ts
@@ -23,6 +23,16 @@ function buildGeminiUrl(model: string, apiKey: string): string {
 }
 
 function toGeminiBody(request: LlmCompletionRequest, model: string): RequestInit {
+  return toGeminiRequest(request, model);
+}
+
+function toGeminiRequest(
+  request: LlmCompletionRequest,
+  model: string,
+  responseMimeType?: string
+): RequestInit {
+  const systemMessage = request.messages.find((message) => message.role === "system");
+
   return {
     method: "POST",
     headers: {
@@ -32,11 +42,11 @@ function toGeminiBody(request: LlmCompletionRequest, model: string): RequestInit
       generationConfig: {
         temperature: request.temperature ?? 0,
         maxOutputTokens: request.maxTokens,
-        responseMimeType: "application/json",
+        responseMimeType,
       },
-      systemInstruction: request.messages.find((message) => message.role === "system")
+      systemInstruction: systemMessage
         ? {
-            parts: [{ text: request.messages.find((message) => message.role === "system")?.content ?? "" }],
+            parts: [{ text: systemMessage.content }],
           }
         : undefined,
       contents: request.messages
@@ -75,11 +85,23 @@ function createGeminiClient(options: ResolvedLlmClientOptions): LlmClient {
     },
 
     async completeJson<T>(request: LlmJsonRequest): Promise<T> {
-      const response = await this.complete(request);
-      if (!response.content) {
+      const model = request.model ?? options.model;
+      const apiKey = options.secrets.geminiApiKey ?? options.secrets.apiKey ?? "";
+      const rawResponse = await fetch(
+        buildGeminiUrl(model, apiKey),
+        toGeminiRequest(request, model, "application/json")
+      );
+
+      if (!rawResponse.ok) {
+        throw new Error(`Gemini request failed with status ${rawResponse.status}.`);
+      }
+
+      const payload = (await rawResponse.json()) as GeminiResponse;
+      const response = extractGeminiText(payload);
+      if (!response) {
         throw new Error("Provider gemini returned an empty JSON response.");
       }
-      return JSON.parse(response.content) as T;
+      return JSON.parse(response) as T;
     },
   };
 }

--- a/search-engine/src/lib/llm/providers/gemini.ts
+++ b/search-engine/src/lib/llm/providers/gemini.ts
@@ -1,0 +1,97 @@
+import type {
+  LlmClient,
+  LlmCompletionRequest,
+  LlmCompletionResponse,
+  LlmJsonRequest,
+  RegisteredLlmProvider,
+  ResolvedLlmClientOptions,
+} from "@search/lib/llm/types";
+
+type GeminiCandidate = {
+  content?: {
+    parts?: Array<{ text?: string }>;
+  };
+};
+
+type GeminiResponse = {
+  candidates?: GeminiCandidate[];
+};
+
+function buildGeminiUrl(model: string, apiKey: string): string {
+  const encodedModel = encodeURIComponent(model);
+  return `https://generativelanguage.googleapis.com/v1beta/models/${encodedModel}:generateContent?key=${apiKey}`;
+}
+
+function toGeminiBody(request: LlmCompletionRequest, model: string): RequestInit {
+  return {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      generationConfig: {
+        temperature: request.temperature ?? 0,
+        maxOutputTokens: request.maxTokens,
+        responseMimeType: "application/json",
+      },
+      systemInstruction: request.messages.find((message) => message.role === "system")
+        ? {
+            parts: [{ text: request.messages.find((message) => message.role === "system")?.content ?? "" }],
+          }
+        : undefined,
+      contents: request.messages
+        .filter((message) => message.role !== "system")
+        .map((message) => ({
+          role: message.role === "assistant" ? "model" : "user",
+          parts: [{ text: message.content }],
+        })),
+      model,
+    }),
+  };
+}
+
+function extractGeminiText(response: GeminiResponse): string {
+  return response.candidates?.[0]?.content?.parts?.map((part) => part.text ?? "").join("").trim() ?? "";
+}
+
+function createGeminiClient(options: ResolvedLlmClientOptions): LlmClient {
+  return {
+    async complete(request: LlmCompletionRequest): Promise<LlmCompletionResponse> {
+      const model = request.model ?? options.model;
+      const apiKey = options.secrets.geminiApiKey ?? options.secrets.apiKey ?? "";
+      const response = await fetch(buildGeminiUrl(model, apiKey), toGeminiBody(request, model));
+
+      if (!response.ok) {
+        throw new Error(`Gemini request failed with status ${response.status}.`);
+      }
+
+      const payload = (await response.json()) as GeminiResponse;
+      return {
+        content: extractGeminiText(payload),
+        model,
+        provider: "gemini",
+        raw: payload,
+      };
+    },
+
+    async completeJson<T>(request: LlmJsonRequest): Promise<T> {
+      const response = await this.complete(request);
+      if (!response.content) {
+        throw new Error("Provider gemini returned an empty JSON response.");
+      }
+      return JSON.parse(response.content) as T;
+    },
+  };
+}
+
+export function createGeminiProvider(): RegisteredLlmProvider {
+  return {
+    name: "gemini",
+    displayName: "Google Gemini",
+    capabilities: {
+      supportsStreaming: false,
+      supportsJsonMode: true,
+    },
+    createClient: (options) => createGeminiClient(options),
+  };
+}

--- a/search-engine/src/lib/llm/providers/index.ts
+++ b/search-engine/src/lib/llm/providers/index.ts
@@ -1,0 +1,23 @@
+import { registerLlmProvider } from "@search/lib/llm/factory";
+import { createGeminiProvider } from "@search/lib/llm/providers/gemini";
+import {
+  createCopilotProvider,
+  createOllamaProvider,
+  createOpenAIProvider,
+} from "@search/lib/llm/providers/openai-compatible";
+
+let defaultsRegistered = false;
+
+export function registerDefaultLlmProviders(): void {
+  if (defaultsRegistered) return;
+
+  registerLlmProvider(createCopilotProvider());
+  registerLlmProvider(createOpenAIProvider());
+  registerLlmProvider(createGeminiProvider());
+  registerLlmProvider(createOllamaProvider());
+  defaultsRegistered = true;
+}
+
+export function resetDefaultLlmProvidersRegistration(): void {
+  defaultsRegistered = false;
+}

--- a/search-engine/src/lib/llm/providers/openai-compatible.ts
+++ b/search-engine/src/lib/llm/providers/openai-compatible.ts
@@ -14,6 +14,7 @@ type OpenAICompatibleConfig = {
   provider: LlmProviderName;
   displayName: string;
   baseURL?: string;
+  resolveBaseUrl?: (options: ResolvedLlmClientOptions) => string | undefined;
   defaultHeaders?: Record<string, string>;
   resolveApiKey: (options: ResolvedLlmClientOptions) => string;
 };
@@ -28,7 +29,7 @@ function toOpenAIMessages(messages: LlmMessage[]): Array<{ role: LlmMessage["rol
 function createOpenAIClient(options: ResolvedLlmClientOptions, config: OpenAICompatibleConfig): OpenAI {
   return new OpenAI({
     apiKey: config.resolveApiKey(options),
-    baseURL: config.baseURL,
+    baseURL: config.resolveBaseUrl?.(options) ?? config.baseURL,
     defaultHeaders: config.defaultHeaders,
     timeout: options.timeoutMs,
     maxRetries: options.maxRetries,
@@ -140,7 +141,7 @@ export function createOllamaProvider(): RegisteredLlmProvider {
   return createOpenAICompatibleProvider({
     provider: "ollama",
     displayName: "Ollama",
-    baseURL: "http://localhost:11434/v1",
+    resolveBaseUrl: (options) => options.secrets.ollamaBaseUrl ?? options.secrets.baseUrl ?? "http://localhost:11434/v1",
     resolveApiKey: () => "ollama",
   });
 }

--- a/search-engine/src/lib/llm/providers/openai-compatible.ts
+++ b/search-engine/src/lib/llm/providers/openai-compatible.ts
@@ -1,0 +1,146 @@
+import OpenAI from "openai";
+import type {
+  LlmClient,
+  LlmCompletionRequest,
+  LlmCompletionResponse,
+  LlmJsonRequest,
+  LlmMessage,
+  LlmProviderName,
+  RegisteredLlmProvider,
+  ResolvedLlmClientOptions,
+} from "@search/lib/llm/types";
+
+type OpenAICompatibleConfig = {
+  provider: LlmProviderName;
+  displayName: string;
+  baseURL?: string;
+  defaultHeaders?: Record<string, string>;
+  resolveApiKey: (options: ResolvedLlmClientOptions) => string;
+};
+
+function toOpenAIMessages(messages: LlmMessage[]): Array<{ role: LlmMessage["role"]; content: string }> {
+  return messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+  }));
+}
+
+function createOpenAIClient(options: ResolvedLlmClientOptions, config: OpenAICompatibleConfig): OpenAI {
+  return new OpenAI({
+    apiKey: config.resolveApiKey(options),
+    baseURL: config.baseURL,
+    defaultHeaders: config.defaultHeaders,
+    timeout: options.timeoutMs,
+    maxRetries: options.maxRetries,
+  });
+}
+
+function mapCompletionResponse(
+  provider: LlmProviderName,
+  model: string,
+  response: { choices?: Array<{ message?: { content?: string | null } }> }
+): LlmCompletionResponse {
+  return {
+    content: response.choices?.[0]?.message?.content?.trim() ?? "",
+    model,
+    provider,
+    raw: response,
+  };
+}
+
+function createOpenAICompatibleClient(
+  options: ResolvedLlmClientOptions,
+  config: OpenAICompatibleConfig
+): LlmClient {
+  const client = createOpenAIClient(options, config);
+
+  return {
+    async complete(request: LlmCompletionRequest): Promise<LlmCompletionResponse> {
+      const model = request.model ?? options.model;
+      const response = await client.chat.completions.create({
+        model,
+        temperature: request.temperature ?? 0,
+        max_tokens: request.maxTokens,
+        messages: toOpenAIMessages(request.messages),
+      });
+
+      return mapCompletionResponse(config.provider, model, response);
+    },
+
+    async *stream(request: LlmCompletionRequest): AsyncIterable<string> {
+      const model = request.model ?? options.model;
+      const stream = await client.chat.completions.create({
+        model,
+        temperature: request.temperature ?? 0,
+        max_tokens: request.maxTokens,
+        stream: true,
+        messages: toOpenAIMessages(request.messages),
+      });
+
+      for await (const chunk of stream) {
+        const token = chunk.choices[0]?.delta?.content;
+        if (token) yield token;
+      }
+    },
+
+    async completeJson<T>(request: LlmJsonRequest): Promise<T> {
+      const model = request.model ?? options.model;
+      const response = await client.chat.completions.create({
+        model,
+        temperature: request.temperature ?? 0,
+        max_tokens: request.maxTokens,
+        response_format: { type: "json_object" },
+        messages: toOpenAIMessages(request.messages),
+      });
+
+      const content = response.choices[0]?.message?.content;
+      if (!content) {
+        throw new Error(`Provider ${config.provider} returned an empty JSON response.`);
+      }
+
+      return JSON.parse(content) as T;
+    },
+  };
+}
+
+export function createOpenAICompatibleProvider(config: OpenAICompatibleConfig): RegisteredLlmProvider {
+  return {
+    name: config.provider,
+    displayName: config.displayName,
+    capabilities: {
+      supportsStreaming: true,
+      supportsJsonMode: true,
+    },
+    createClient: (options) => createOpenAICompatibleClient(options, config),
+  };
+}
+
+export function createCopilotProvider(): RegisteredLlmProvider {
+  return createOpenAICompatibleProvider({
+    provider: "copilot",
+    displayName: "GitHub Copilot",
+    baseURL: "https://models.github.ai/inference",
+    defaultHeaders: {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    resolveApiKey: (options) => options.secrets.githubToken ?? "",
+  });
+}
+
+export function createOpenAIProvider(): RegisteredLlmProvider {
+  return createOpenAICompatibleProvider({
+    provider: "openai",
+    displayName: "OpenAI",
+    resolveApiKey: (options) => options.secrets.openAIApiKey ?? options.secrets.apiKey ?? "",
+  });
+}
+
+export function createOllamaProvider(): RegisteredLlmProvider {
+  return createOpenAICompatibleProvider({
+    provider: "ollama",
+    displayName: "Ollama",
+    baseURL: "http://localhost:11434/v1",
+    resolveApiKey: () => "ollama",
+  });
+}


### PR DESCRIPTION
## Summary
- add OpenAI-compatible provider adapters for Copilot, OpenAI, and Ollama
- add a Gemini adapter with normalized completion and JSON response handling
- add default provider registration helpers for the factory registry
- add focused provider tests covering registration and adapter invocation

## Validation
- `npm run test:run -- src/__tests__/llm-factory.test.ts src/__tests__/llm-providers.test.ts`

Closes #64