### PR TITLE
feat(search-engine): add LLM fallback resilience layer

### DIFF
--- a/search-engine/src/__tests__/llm-resilience.test.ts
+++ b/search-engine/src/__tests__/llm-resilience.test.ts
@@ -126,4 +126,25 @@ describe("llm resilience", () => {
       })
     ).rejects.toThrow("provider unavailable");
   });
+
+  it("does not fail over on unknown non-retriable errors", async () => {
+    registerLlmProvider(
+      createProvider("copilot", async () => {
+        throw new Error("missing prompt template");
+      })
+    );
+    registerLlmProvider(createProvider("openai", async () => "should not run"));
+
+    await expect(
+      executeWithFallback({
+        clientOptions: {
+          purpose: "chat",
+          model: "gpt-4o-mini",
+          secrets: { githubToken: "github-token", openAIApiKey: "openai-key" },
+        },
+        providers: ["copilot", "openai"],
+        execute: async (client) => (await client.complete({ messages: [{ role: "user", content: "hello" }] })).content,
+      })
+    ).rejects.toThrow("missing prompt template");
+  });
 });

--- a/search-engine/src/__tests__/llm-resilience.test.ts
+++ b/search-engine/src/__tests__/llm-resilience.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearLlmProviderRegistry,
+  registerLlmProvider,
+} from "@search/lib/llm/factory";
+import {
+  classifyLlmError,
+  executeWithFallback,
+  isProviderCircuitOpen,
+  recordProviderFailure,
+  resetProviderCircuitState,
+  resolveProviderOrder,
+} from "@search/lib/llm/resilience";
+import type { LlmClient, RegisteredLlmProvider } from "@search/lib/llm/types";
+
+function createProvider(
+  name: RegisteredLlmProvider["name"],
+  behavior: () => Promise<string>
+): RegisteredLlmProvider {
+  const client: LlmClient = {
+    async complete() {
+      return {
+        content: await behavior(),
+        model: "test-model",
+        provider: name,
+      };
+    },
+  };
+
+  return {
+    name,
+    displayName: `${name} test`,
+    capabilities: {
+      supportsStreaming: true,
+      supportsJsonMode: true,
+    },
+    createClient: () => client,
+  };
+}
+
+describe("llm resilience", () => {
+  beforeEach(() => {
+    clearLlmProviderRegistry();
+    resetProviderCircuitState();
+    delete process.env.LLM_FALLBACK_ORDER_CHAT;
+  });
+
+  afterEach(() => {
+    clearLlmProviderRegistry();
+    resetProviderCircuitState();
+    delete process.env.LLM_FALLBACK_ORDER_CHAT;
+  });
+
+  it("uses env-configured provider order when present", () => {
+    process.env.LLM_FALLBACK_ORDER_CHAT = "openai,gemini,ollama";
+
+    expect(resolveProviderOrder("chat")).toEqual(["openai", "gemini", "ollama"]);
+  });
+
+  it("classifies upstream rate-limit errors", () => {
+    expect(classifyLlmError({ statusCode: 429 })).toBe("rate-limit");
+    expect(classifyLlmError(new Error("Too many requests from upstream"))).toBe("rate-limit");
+  });
+
+  it("falls back to the next provider on rate-limit failure", async () => {
+    registerLlmProvider(
+      createProvider("copilot", async () => {
+        const error = new Error("Too many requests");
+        (error as Error & { statusCode?: number }).statusCode = 429;
+        throw error;
+      })
+    );
+    registerLlmProvider(createProvider("openai", async () => "openai success"));
+
+    const events: string[] = [];
+    const result = await executeWithFallback({
+      clientOptions: {
+        purpose: "chat",
+        model: "gpt-4o-mini",
+        secrets: { githubToken: "github-token", openAIApiKey: "openai-key" },
+      },
+      providers: ["copilot", "openai"],
+      execute: async (client) => (await client.complete({ messages: [{ role: "user", content: "hello" }] })).content,
+      onFallback: (event) => events.push(`${event.from}->${event.to}:${event.errorType}`),
+    });
+
+    expect(result.provider).toBe("openai");
+    expect(result.result).toBe("openai success");
+    expect(events).toEqual(["copilot->openai:rate-limit"]);
+  });
+
+  it("opens the provider circuit after repeated failures", () => {
+    recordProviderFailure("copilot", 2, 1_000, 10);
+    expect(isProviderCircuitOpen("copilot", 10)).toBe(false);
+
+    recordProviderFailure("copilot", 2, 1_000, 20);
+    expect(isProviderCircuitOpen("copilot", 100)).toBe(true);
+    expect(isProviderCircuitOpen("copilot", 1_100)).toBe(false);
+  });
+
+  it("throws when every provider fails", async () => {
+    registerLlmProvider(
+      createProvider("copilot", async () => {
+        const error = new Error("Too many requests");
+        (error as Error & { statusCode?: number }).statusCode = 429;
+        throw error;
+      })
+    );
+    registerLlmProvider(
+      createProvider("openai", async () => {
+        const error = new Error("provider unavailable");
+        (error as Error & { statusCode?: number }).statusCode = 503;
+        throw error;
+      })
+    );
+
+    await expect(
+      executeWithFallback({
+        clientOptions: {
+          purpose: "chat",
+          model: "gpt-4o-mini",
+          secrets: { githubToken: "github-token", openAIApiKey: "openai-key" },
+        },
+        providers: ["copilot", "openai"],
+        execute: async (client) => (await client.complete({ messages: [{ role: "user", content: "hello" }] })).content,
+      })
+    ).rejects.toThrow("provider unavailable");
+  });
+});

--- a/search-engine/src/lib/llm/resilience.ts
+++ b/search-engine/src/lib/llm/resilience.ts
@@ -137,6 +137,11 @@ export async function executeWithFallback<T>(
     } catch (error) {
       lastError = error;
       const errorType = classifyLlmError(error);
+
+      if (errorType === "unknown") {
+        throw error;
+      }
+
       recordProviderFailure(
         provider,
         options.failureThreshold ?? DEFAULT_FAILURE_THRESHOLD,
@@ -148,10 +153,6 @@ export async function executeWithFallback<T>(
         const event = { from: provider, to: nextProvider, errorType };
         failovers.push(event);
         options.onFallback?.(event);
-      }
-
-      if (errorType === "unknown" && !nextProvider) {
-        throw error;
       }
     }
   }

--- a/search-engine/src/lib/llm/resilience.ts
+++ b/search-engine/src/lib/llm/resilience.ts
@@ -1,0 +1,160 @@
+import { createLlmClient } from "@search/lib/llm/factory";
+import type { LlmClient, LlmClientOptions, LlmProviderName, LlmPurpose } from "@search/lib/llm/types";
+
+const DEFAULT_FAILURE_THRESHOLD = 3;
+const DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;
+
+const DEFAULT_PROVIDER_ORDER: Record<LlmPurpose, LlmProviderName[]> = {
+  chat: ["copilot", "openai", "gemini", "ollama"],
+  router: ["copilot", "openai", "ollama"],
+  "grounded-answer": ["copilot", "openai", "gemini", "ollama"],
+  extraction: ["copilot", "openai", "ollama"],
+};
+
+type CircuitState = {
+  consecutiveFailures: number;
+  openUntil: number;
+};
+
+type ProviderErrorType = "rate-limit" | "server-error" | "timeout" | "unknown";
+
+const circuitByProvider = new Map<LlmProviderName, CircuitState>();
+
+export interface LlmFallbackEvent {
+  from: LlmProviderName;
+  to: LlmProviderName;
+  errorType: ProviderErrorType;
+}
+
+export interface ExecuteWithFallbackOptions<T> {
+  clientOptions: Omit<LlmClientOptions, "provider"> & { purpose: LlmPurpose };
+  providers?: LlmProviderName[];
+  execute: (client: LlmClient, provider: LlmProviderName) => Promise<T>;
+  onFallback?: (event: LlmFallbackEvent) => void;
+  failureThreshold?: number;
+  cooldownMs?: number;
+}
+
+export interface ExecuteWithFallbackResult<T> {
+  provider: LlmProviderName;
+  result: T;
+  failovers: LlmFallbackEvent[];
+}
+
+function now(): number {
+  return Date.now();
+}
+
+function parseProviderList(value?: string): LlmProviderName[] {
+  if (!value?.trim()) return [];
+  return value
+    .split(",")
+    .map((item) => item.trim().toLowerCase())
+    .filter((item): item is LlmProviderName => {
+      return item === "copilot" || item === "openai" || item === "gemini" || item === "ollama";
+    });
+}
+
+export function resolveProviderOrder(purpose: LlmPurpose, explicit?: LlmProviderName[]): LlmProviderName[] {
+  if (explicit?.length) return explicit;
+
+  const envOrder = parseProviderList(process.env[`LLM_FALLBACK_ORDER_${purpose.replace(/-/g, "_").toUpperCase()}`]);
+  if (envOrder.length) return envOrder;
+
+  return DEFAULT_PROVIDER_ORDER[purpose];
+}
+
+export function classifyLlmError(error: unknown): ProviderErrorType {
+  const message = `${(error as { message?: string })?.message ?? ""}`.toLowerCase();
+  const statusCode = (error as { statusCode?: number })?.statusCode;
+
+  if (statusCode === 429 || message.includes("too many requests") || message.includes("rate limit")) {
+    return "rate-limit";
+  }
+
+  if (statusCode != null && statusCode >= 500) {
+    return "server-error";
+  }
+
+  if (message.includes("timeout") || message.includes("aborted")) {
+    return "timeout";
+  }
+
+  return "unknown";
+}
+
+function getCircuitState(provider: LlmProviderName): CircuitState {
+  return circuitByProvider.get(provider) ?? { consecutiveFailures: 0, openUntil: 0 };
+}
+
+export function isProviderCircuitOpen(provider: LlmProviderName, currentTime = now()): boolean {
+  return getCircuitState(provider).openUntil > currentTime;
+}
+
+export function recordProviderSuccess(provider: LlmProviderName): void {
+  circuitByProvider.set(provider, { consecutiveFailures: 0, openUntil: 0 });
+}
+
+export function recordProviderFailure(
+  provider: LlmProviderName,
+  failureThreshold = DEFAULT_FAILURE_THRESHOLD,
+  cooldownMs = DEFAULT_COOLDOWN_MS,
+  currentTime = now()
+): void {
+  const current = getCircuitState(provider);
+  const consecutiveFailures = current.consecutiveFailures + 1;
+
+  if (consecutiveFailures >= failureThreshold) {
+    circuitByProvider.set(provider, { consecutiveFailures: 0, openUntil: currentTime + cooldownMs });
+    return;
+  }
+
+  circuitByProvider.set(provider, { consecutiveFailures, openUntil: current.openUntil });
+}
+
+export function resetProviderCircuitState(): void {
+  circuitByProvider.clear();
+}
+
+export async function executeWithFallback<T>(
+  options: ExecuteWithFallbackOptions<T>
+): Promise<ExecuteWithFallbackResult<T>> {
+  const providers = resolveProviderOrder(options.clientOptions.purpose, options.providers);
+  const failovers: LlmFallbackEvent[] = [];
+  let lastError: unknown;
+
+  for (let index = 0; index < providers.length; index += 1) {
+    const provider = providers[index];
+    if (isProviderCircuitOpen(provider)) {
+      continue;
+    }
+
+    try {
+      const client = await createLlmClient({ ...options.clientOptions, provider });
+      const result = await options.execute(client, provider);
+      recordProviderSuccess(provider);
+      return { provider, result, failovers };
+    } catch (error) {
+      lastError = error;
+      const errorType = classifyLlmError(error);
+      recordProviderFailure(
+        provider,
+        options.failureThreshold ?? DEFAULT_FAILURE_THRESHOLD,
+        options.cooldownMs ?? DEFAULT_COOLDOWN_MS
+      );
+
+      const nextProvider = providers[index + 1];
+      if (nextProvider) {
+        const event = { from: provider, to: nextProvider, errorType };
+        failovers.push(event);
+        options.onFallback?.(event);
+      }
+
+      if (errorType === "unknown" && !nextProvider) {
+        throw error;
+      }
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("No available LLM provider succeeded.");
+}


### PR DESCRIPTION
## Summary
- add a reusable fallback executor around `createLlmClient`
- add provider order resolution by purpose with env override support
- add in-memory circuit breaker state and provider error classification
- add focused tests for fallback, rate-limit classification, and circuit opening

## Validation
- `npm run test:run -- src/__tests__/llm-factory.test.ts src/__tests__/llm-providers.test.ts src/__tests__/llm-resilience.test.ts`

Closes #65