### PR TITLE
feat(search-engine): migrate runtime LLM call sites to factory

### DIFF
--- a/search-engine/src/app/api/chat/route.ts
+++ b/search-engine/src/app/api/chat/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createOpenAI } from "@ai-sdk/openai";
-import { createUIMessageStream, createUIMessageStreamResponse, streamText } from "ai";
+import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { HybridRetriever } from "@search/lib/hybrid-retriever";
 import { getDb } from "@search/lib/mongodb";
+import { registerDefaultLlmProviders } from "@search/lib/llm/providers";
+import { executeWithFallback } from "@search/lib/llm/resilience";
 import { rateLimit } from "@search/lib/rate-limit";
 import { routeQuery } from "@search/lib/query-router";
 import {
@@ -14,31 +15,7 @@ import {
 const UNKNOWN_RESPONSE = "Je ne sais pas d'après les Écritures fournies.";
 const DEFAULT_MODEL = process.env.GROUNDED_ANSWER_MODEL ?? "gpt-4o-mini";
 
-// Custom fetch wrapper to add GitHub authentication headers
-const customFetch = (
-  input: string | Request | URL,
-  options?: RequestInit
-): Promise<Response> => {
-  const token = process.env.GITHUB_TOKEN;
-  const headers = new Headers(options?.headers || {});
-  
-  // Ensure Authorization header is set
-  if (token && !headers.has("Authorization")) {
-    headers.set("Authorization", `Bearer ${token}`);
-  }
-  
-  // Add GitHub-specific headers
-  headers.set("Accept", "application/vnd.github+json");
-  headers.set("X-GitHub-Api-Version", "2022-11-28");
-  
-  return fetch(input, { ...options, headers });
-};
-
-const github = createOpenAI({
-  apiKey: process.env.GITHUB_TOKEN,
-  baseURL: "https://models.github.ai/inference",
-  fetch: customFetch,
-});
+registerDefaultLlmProviders();
 
 type ChatPart = { type?: string; text?: string };
 type ChatMessage = {
@@ -160,9 +137,14 @@ export async function POST(req: NextRequest): Promise<Response> {
     );
   }
 
-  if (!process.env.GITHUB_TOKEN) {
+  if (
+    !process.env.GITHUB_TOKEN &&
+    !process.env.OPENAI_API_KEY &&
+    !process.env.GEMINI_API_KEY &&
+    !process.env.OLLAMA_BASE_URL
+  ) {
     return NextResponse.json(
-      { error: "Server misconfiguration: missing GITHUB_TOKEN." },
+      { error: "Server misconfiguration: no LLM provider credentials configured." },
       { status: 500 }
     );
   }
@@ -204,20 +186,70 @@ export async function POST(req: NextRequest): Promise<Response> {
       return createStaticAssistantResponse(UNKNOWN_RESPONSE);
     }
 
-    const result = streamText({
-      model: github.chat(DEFAULT_MODEL),
-      temperature: 0,
-      maxRetries: 0,
-      system: buildGroundedStreamingSystemPrompt(),
-      prompt: [
-        `Question: ${query}`,
-        "",
-        "Context:",
-        context.text,
-      ].join("\n"),
+    const stream = createUIMessageStream({
+      execute: async ({ writer }) => {
+        const textId = "chat-response";
+
+        writer.write({ type: "text-start", id: textId });
+        try {
+          await executeWithFallback({
+            clientOptions: {
+              purpose: "chat",
+              model: DEFAULT_MODEL,
+            },
+            execute: async (client) => {
+              if (client.stream) {
+                for await (const token of client.stream({
+                  model: DEFAULT_MODEL,
+                  temperature: 0,
+                  messages: [
+                    { role: "system", content: buildGroundedStreamingSystemPrompt() },
+                    {
+                      role: "user",
+                      content: [
+                        `Question: ${query}`,
+                        "",
+                        "Context:",
+                        context.text,
+                      ].join("\n"),
+                    },
+                  ],
+                })) {
+                  writer.write({ type: "text-delta", id: textId, delta: token });
+                }
+                return;
+              }
+
+              const response = await client.complete({
+                model: DEFAULT_MODEL,
+                temperature: 0,
+                messages: [
+                  { role: "system", content: buildGroundedStreamingSystemPrompt() },
+                  {
+                    role: "user",
+                    content: [
+                      `Question: ${query}`,
+                      "",
+                      "Context:",
+                      context.text,
+                    ].join("\n"),
+                  },
+                ],
+              });
+
+              if (response.content) {
+                writer.write({ type: "text-delta", id: textId, delta: response.content });
+              }
+            },
+          });
+        } finally {
+          writer.write({ type: "text-end", id: textId });
+        }
+      },
     });
 
-    return result.toUIMessageStreamResponse({
+    return createUIMessageStreamResponse({
+      stream,
       headers: {
         "Cache-Control": "no-cache, no-transform",
       },

--- a/search-engine/src/lib/context-injection.ts
+++ b/search-engine/src/lib/context-injection.ts
@@ -1,16 +1,8 @@
-import OpenAI from "openai";
+import { registerDefaultLlmProviders } from "@search/lib/llm/providers";
+import { executeWithFallback } from "@search/lib/llm/resilience";
 import type { EntityFact, VerseResult } from "@search/types/hybrid";
 
-function createCopilotClient(): OpenAI {
-  return new OpenAI({
-    apiKey: process.env.GITHUB_TOKEN ?? "none",
-    baseURL: "https://models.github.ai/inference",
-    defaultHeaders: {
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-    },
-  });
-}
+registerDefaultLlmProviders();
 
 const DEFAULT_MODEL = process.env.GROUNDED_ANSWER_MODEL ?? "gpt-4o-mini";
 const UNKNOWN_RESPONSE = "Je ne sais pas d'après les Écritures fournies.";
@@ -167,16 +159,6 @@ export async function generateGroundedAnswerStream(input: StreamGroundedAnswerIn
     };
   }
 
-  if (!process.env.GITHUB_TOKEN) {
-    return {
-      answer: UNKNOWN_RESPONSE,
-      citations: [],
-      uncertain: true,
-      model,
-      promptVersion: PROMPT_VERSION,
-    };
-  }
-
   const context = assembleHybridContext(input.verses, input.entityFacts);
 
   if (!context.references.length) {
@@ -189,34 +171,59 @@ export async function generateGroundedAnswerStream(input: StreamGroundedAnswerIn
     };
   }
 
-  const openai = createCopilotClient();
-
   try {
-    const stream = await openai.chat.completions.create({
-      model,
-      temperature: 0,
-      stream: true,
-      messages: [
-        { role: "system", content: buildGroundedStreamingSystemPrompt() },
-        {
-          role: "user",
-          content: [
-            `Question: ${input.query}`,
-            "",
-            "Context:",
-            context.text,
-          ].join("\n"),
-        },
-      ],
-    });
-
     let answer = "";
-    for await (const chunk of stream) {
-      const token = chunk.choices[0]?.delta?.content;
-      if (!token) continue;
-      answer += token;
-      input.onToken(token);
-    }
+    await executeWithFallback({
+      clientOptions: {
+        purpose: "grounded-answer",
+        model,
+      },
+      execute: async (client) => {
+        if (client.stream) {
+          for await (const token of client.stream({
+            model,
+            temperature: 0,
+            messages: [
+              { role: "system", content: buildGroundedStreamingSystemPrompt() },
+              {
+                role: "user",
+                content: [
+                  `Question: ${input.query}`,
+                  "",
+                  "Context:",
+                  context.text,
+                ].join("\n"),
+              },
+            ],
+          })) {
+            answer += token;
+            input.onToken(token);
+          }
+          return answer;
+        }
+
+        const response = await client.complete({
+          model,
+          temperature: 0,
+          messages: [
+            { role: "system", content: buildGroundedStreamingSystemPrompt() },
+            {
+              role: "user",
+              content: [
+                `Question: ${input.query}`,
+                "",
+                "Context:",
+                context.text,
+              ].join("\n"),
+            },
+          ],
+        });
+
+        answer = response.content;
+        if (answer) input.onToken(answer);
+        return answer;
+      },
+    });
 
     const cleaned = answer.trim() || UNKNOWN_RESPONSE;
     const citations = extractCitations(cleaned);
@@ -269,16 +276,6 @@ export async function generateGroundedAnswer(input: {
     };
   }
 
-  if (!process.env.GITHUB_TOKEN) {
-    return {
-      answer: UNKNOWN_RESPONSE,
-      citations: [],
-      uncertain: true,
-      model,
-      promptVersion: PROMPT_VERSION,
-    };
-  }
-
   const context = assembleHybridContext(input.verses, input.entityFacts);
 
   if (!context.references.length) {
@@ -291,29 +288,32 @@ export async function generateGroundedAnswer(input: {
     };
   }
 
-  const openai = createCopilotClient();
-
   try {
-    const completion = await openai.chat.completions.create({
-      model,
-      temperature: 0,
-      response_format: { type: "json_object" },
-      messages: [
-        { role: "system", content: buildGroundedSystemPrompt() },
-        {
-          role: "user",
-          content: [
-            `Question: ${input.query}`,
-            "",
-            "Context:",
-            context.text,
-          ].join("\n"),
-        },
-      ],
+    const { result: parsed } = await executeWithFallback<{ answer?: string; usedReferences?: string[] }>({
+      clientOptions: {
+        purpose: "grounded-answer",
+        model,
+      },
+      execute: (client) =>
+        client.completeJson?.<{ answer?: string; usedReferences?: string[] }>({
+          model,
+          temperature: 0,
+          messages: [
+            { role: "system", content: buildGroundedSystemPrompt() },
+            {
+              role: "user",
+              content: [
+                `Question: ${input.query}`,
+                "",
+                "Context:",
+                context.text,
+              ].join("\n"),
+            },
+          ],
+        }) ?? Promise.reject(new Error("Provider does not support JSON completion.")),
     });
 
-    const content = completion.choices[0]?.message?.content;
-    if (!content) {
+    if (!parsed) {
       return {
         answer: UNKNOWN_RESPONSE,
         citations: [],
@@ -323,7 +323,6 @@ export async function generateGroundedAnswer(input: {
       };
     }
 
-    const parsed = JSON.parse(content) as { answer?: string; usedReferences?: string[] };
     const answer = parsed.answer?.trim() || UNKNOWN_RESPONSE;
     const inlineCitations = extractCitations(answer);
     const references = (parsed.usedReferences ?? []).filter(Boolean);

--- a/search-engine/src/lib/query-router.ts
+++ b/search-engine/src/lib/query-router.ts
@@ -1,16 +1,8 @@
-import OpenAI from "openai";
+import { registerDefaultLlmProviders } from "@search/lib/llm/providers";
+import { executeWithFallback } from "@search/lib/llm/resilience";
 import type { HybridFilters, QueryIntent } from "@search/types/hybrid";
 
-function createCopilotClient(): OpenAI {
-  return new OpenAI({
-    apiKey: process.env.GITHUB_TOKEN ?? "none",
-    baseURL: "https://models.github.ai/inference",
-    defaultHeaders: {
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-    },
-  });
-}
+registerDefaultLlmProviders();
 
 type RouterDecisionShape = {
   intent: QueryIntent;
@@ -314,43 +306,33 @@ function heuristicRoute(query: string): QueryRoutingDecision {
 }
 
 async function llmRoute(query: string, timeoutMs: number): Promise<QueryRoutingDecision | null> {
-  if (!process.env.GITHUB_TOKEN) {
-    return null;
-  }
-
-  const openai = createCopilotClient();
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   const startedAt = Date.now();
 
   try {
-    const completion = await openai.chat.completions.create(
-      {
+    const { result: parsed } = await executeWithFallback<Partial<RouterDecisionShape>>({
+      clientOptions: {
+        purpose: "router",
         model: ROUTER_MODEL,
-        temperature: 0,
-        response_format: { type: "json_object" },
-        messages: [
-          {
-            role: "system",
-            content:
-              "You are a multilingual (English/French) query router for Bible retrieval. Return only JSON with this schema: { intent, vectorWeight, graphWeight, bm25Weight, k, filters: { testament?, book? }, reasoning }. intent must be one of THEOLOGY, GENEALOGY, GEOGRAPHY, CHRONOLOGY, GENERAL. Canonicalize book names to LSG French names (e.g., Genese -> Genèse, Matthew -> Matthieu). Prefer French testament labels (Ancien Testament / Nouveau Testament). Ensure vectorWeight + graphWeight + bm25Weight ~= 1. Keep reasoning under 160 chars.",
-          },
-          {
-            role: "user",
-            content: query,
-          },
-        ],
+        timeoutMs,
       },
-      { signal: controller.signal }
-    );
+      execute: (client) =>
+        client.completeJson?.<Partial<RouterDecisionShape>>({
+          model: ROUTER_MODEL,
+          temperature: 0,
+          messages: [
+            {
+              role: "system",
+              content:
+                "You are a multilingual (English/French) query router for Bible retrieval. Return only JSON with this schema: { intent, vectorWeight, graphWeight, bm25Weight, k, filters: { testament?, book? }, reasoning }. intent must be one of THEOLOGY, GENEALOGY, GEOGRAPHY, CHRONOLOGY, GENERAL. Canonicalize book names to LSG French names (e.g., Genese -> Genèse, Matthew -> Matthieu). Prefer French testament labels (Ancien Testament / Nouveau Testament). Ensure vectorWeight + graphWeight + bm25Weight ~= 1. Keep reasoning under 160 chars.",
+            },
+            {
+              role: "user",
+              content: query,
+            },
+          ],
+        }) ?? Promise.reject(new Error("Provider does not support JSON completion.")),
+    });
 
-    const content = completion.choices[0]?.message?.content;
-    if (!content) {
-      return null;
-    }
-
-    const parsed = JSON.parse(content) as Partial<RouterDecisionShape>;
     if (!parsed.intent || !(parsed.intent in INTENT_CONFIG)) {
       return null;
     }
@@ -383,8 +365,6 @@ async function llmRoute(query: string, timeoutMs: number): Promise<QueryRoutingD
     };
   } catch {
     return null;
-  } finally {
-    clearTimeout(timeout);
   }
 }
 


### PR DESCRIPTION
## Summary
- migrate query routing to the provider factory and fallback executor
- migrate grounded answer generation to provider-agnostic runtime clients
- preserve chat UI-message streaming while routing generation through the factory

Closes #66

## Validation
- npm run test:run -- src/__tests__/context-injection.test.ts src/__tests__/query-router.test.ts src/__tests__/chat-route.test.ts src/__tests__/llm-factory.test.ts src/__tests__/llm-providers.test.ts src/__tests__/llm-resilience.test.ts