### PR TITLE
docs(search-engine): document LLM factory rollout

### DIFF
--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -83,10 +83,17 @@ After the workflow succeeds:
 ```bash
 docker pull ghcr.io/<owner>/bible-chat-scholar:v1.2.0
 docker run --rm -p 3000:3000 \
+  -e LLM_DEFAULT_PROVIDER=openai \
   -e OPENAI_API_KEY=<key> \
   -e DATABASE_URL=<uri> \
   ghcr.io/<owner>/bible-chat-scholar:v1.2.0
 ```
+
+For GitHub Models, Gemini, or Ollama smoke tests, swap the provider envs accordingly:
+
+- GitHub Models: `LLM_DEFAULT_PROVIDER=copilot` and `GITHUB_TOKEN=<token>`
+- Gemini: `LLM_DEFAULT_PROVIDER=gemini` and `GEMINI_API_KEY=<key>`
+- Ollama: `LLM_DEFAULT_PROVIDER=ollama` and `OLLAMA_BASE_URL=http://host:11434/v1`
 
 ## Hotfix release (PATCH on a previous version)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,7 +31,9 @@ This roadmap outlines the development of a semantic search and chat engine for t
 - ✅ **Hybrid Retriever** (Combining Vector Search + Graph Traversal) `done` — Adaptive fanout, RRF fusion, entity enrichment
 - ✅ **Agentic Router** (US-009: Logic to decide between semantic search or genealogy graph) `done` — Intent classification, kinship fast profile, French LSG support
 - ✅ **Context Injection** (US-010: System prompts for theological accuracy and sourcing) `done` — Grounded answers, citation validation, anti-hallucination
-- ✅ **Streaming API Handlers** (US-011: Real-time token streaming with SSE) `done` — Native NextResponse stream + GitHub Models (OpenAI SDK)
+- ✅ **Streaming API Handlers** (US-011: Real-time token streaming with SSE) `done` — AI SDK UI-message streams backed by provider factory + fallback executor
+
+- ✅ **LLM Provider Factory Rollout** `done` — Runtime routing, grounded answers, chat streaming, and extraction scripts now share Copilot/OpenAI/Gemini/Ollama selection and fallback policy
 
 ---
 

--- a/search-engine/README.md
+++ b/search-engine/README.md
@@ -1,36 +1,47 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+## Search Engine
+
+Next.js search and chat application for the Bible RAG + knowledge-graph stack.
 
 ## Getting Started
 
-First, run the development server:
+Install dependencies and start the app:
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The app runs on http://localhost:3000.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+Copy `env.example` to `.env.local` and set at least one runtime provider:
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- `GITHUB_TOKEN` for GitHub Models / Copilot
+- `OPENAI_API_KEY` for OpenAI
+- `GEMINI_API_KEY` for Gemini
+- `OLLAMA_BASE_URL` for a local OpenAI-compatible endpoint such as Ollama
 
-## Learn More
+The runtime provider factory supports per-surface selection and fallback via env vars:
 
-To learn more about Next.js, take a look at the following resources:
+- `LLM_DEFAULT_PROVIDER`
+- `LLM_CHAT_PROVIDER`
+- `LLM_ROUTER_PROVIDER`
+- `LLM_GROUNDED_ANSWER_PROVIDER`
+- `LLM_EXTRACTION_PROVIDER`
+- `LLM_FALLBACK_ORDER_CHAT`
+- `LLM_FALLBACK_ORDER_ROUTER`
+- `LLM_FALLBACK_ORDER_GROUNDED_ANSWER`
+- `LLM_FALLBACK_ORDER_EXTRACTION`
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Model overrides are available through `LLM_CHAT_MODEL`, `LLM_ROUTER_MODEL`, `LLM_GROUNDED_ANSWER_MODEL`, and `LLM_EXTRACTION_MODEL`.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Validation
 
-## Deploy on Vercel
+```bash
+npm run test:run
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Notes
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- Embeddings still use `OPENAI_API_KEY`.
+- Chat responses must stay in AI SDK UI-message stream format.
+- Extraction scripts use the same provider factory and fallback policy as runtime paths.

--- a/search-engine/env.example
+++ b/search-engine/env.example
@@ -1,9 +1,35 @@
 DATABASE_URL='mongodb://admin:password@localhost:10260/?directConnection=true&tls=true&tlsAllowInvalidCertificates=true'
 MONGODB_DB_NAME=bible_sg
 MONGODB_COLLECTION_NAME=verses
+
+# Embeddings
 OPENAI_API_KEY=<OPENAI_API_KEY>
+
+# LLM providers
 GITHUB_TOKEN=<github_pat_xxx>
+GEMINI_API_KEY=<gemini_api_key>
+OLLAMA_BASE_URL='http://localhost:11434/v1'
+
+# Default provider selection
+LLM_DEFAULT_PROVIDER=copilot
+LLM_CHAT_PROVIDER=copilot
+LLM_ROUTER_PROVIDER=copilot
+LLM_GROUNDED_ANSWER_PROVIDER=copilot
+LLM_EXTRACTION_PROVIDER=copilot
+
+# Fallback order per workload
+LLM_FALLBACK_ORDER_CHAT='copilot,openai,gemini,ollama'
+LLM_FALLBACK_ORDER_ROUTER='copilot,openai,ollama'
+LLM_FALLBACK_ORDER_GROUNDED_ANSWER='copilot,openai,gemini,ollama'
+LLM_FALLBACK_ORDER_EXTRACTION='copilot,openai,ollama'
+
+# Model overrides
+LLM_CHAT_MODEL=gpt-4o-mini
+LLM_ROUTER_MODEL=gpt-4o-mini
+LLM_GROUNDED_ANSWER_MODEL=gpt-4o-mini
+LLM_EXTRACTION_MODEL=gpt-4o-mini
 COPILOTE_MODEL=gpt-4o-mini
+
 EXTRACT_INPUT_PATH='../data/processed_bible.json'
 EXTRACT_OUTPUT_PATH='../data/raw_graph.enrich.json'
 EXTRACT_BOOKS="GEN,EXO,1SA,MAT,ACT,ROM,HEB"
@@ -11,4 +37,3 @@ EXTRACT_DELAY_MS=20000
 MEILISEARCH_URL='http://localhost:7700'
 MEILISEARCH_API_KEY='masterKey'
 SKIP_MEILISEARCH='false'
-


### PR DESCRIPTION
## Summary
- expand the example environment with provider selection, fallback order, and model override settings
- replace the boilerplate search-engine README with project-specific setup notes for the provider factory
- update roadmap and release guidance to reflect multi-provider rollout paths

Closes #68

## Validation
- Reviewed targeted diff for search-engine/env.example, search-engine/README.md, docs/roadmap.md, and docs/how-to-release.md