### PR TITLE
Fix Gemini 2.5 default provider 404 handling

### DIFF
--- a/search-engine/README.md
+++ b/search-engine/README.md
@@ -15,10 +15,12 @@ The app runs on http://localhost:3000.
 
 Copy `env.example` to `.env.local` and set at least one runtime provider:
 
-- `GITHUB_TOKEN` for GitHub Models / Copilot
-- `OPENAI_API_KEY` for OpenAI
 - `GEMINI_API_KEY` for Gemini
+- `OPENAI_API_KEY` for OpenAI
+- `GITHUB_TOKEN` for GitHub Models / Copilot
 - `OLLAMA_BASE_URL` for a local OpenAI-compatible endpoint such as Ollama
+
+The default runtime configuration targets Gemini first with `gemini-2.5-flash` for chat, router, grounded answer, and extraction. Override any surface with the per-purpose provider and model env vars if you need a different deployment profile.
 
 The runtime provider factory supports per-surface selection and fallback via env vars:
 

--- a/search-engine/env.example
+++ b/search-engine/env.example
@@ -11,23 +11,23 @@ GEMINI_API_KEY=<gemini_api_key>
 OLLAMA_BASE_URL='http://localhost:11434/v1'
 
 # Default provider selection
-LLM_DEFAULT_PROVIDER=copilot
-LLM_CHAT_PROVIDER=copilot
-LLM_ROUTER_PROVIDER=copilot
-LLM_GROUNDED_ANSWER_PROVIDER=copilot
-LLM_EXTRACTION_PROVIDER=copilot
+LLM_DEFAULT_PROVIDER=gemini
+LLM_CHAT_PROVIDER=gemini
+LLM_ROUTER_PROVIDER=gemini
+LLM_GROUNDED_ANSWER_PROVIDER=gemini
+LLM_EXTRACTION_PROVIDER=gemini
 
 # Fallback order per workload
-LLM_FALLBACK_ORDER_CHAT='copilot,openai,gemini,ollama'
-LLM_FALLBACK_ORDER_ROUTER='copilot,openai,ollama'
-LLM_FALLBACK_ORDER_GROUNDED_ANSWER='copilot,openai,gemini,ollama'
-LLM_FALLBACK_ORDER_EXTRACTION='copilot,openai,ollama'
+LLM_FALLBACK_ORDER_CHAT='gemini,openai,copilot,ollama'
+LLM_FALLBACK_ORDER_ROUTER='gemini,openai,copilot,ollama'
+LLM_FALLBACK_ORDER_GROUNDED_ANSWER='gemini,openai,copilot,ollama'
+LLM_FALLBACK_ORDER_EXTRACTION='gemini,openai,copilot,ollama'
 
 # Model overrides
-LLM_CHAT_MODEL=gpt-4o-mini
-LLM_ROUTER_MODEL=gpt-4o-mini
-LLM_GROUNDED_ANSWER_MODEL=gpt-4o-mini
-LLM_EXTRACTION_MODEL=gpt-4o-mini
+LLM_CHAT_MODEL=gemini-2.5-flash
+LLM_ROUTER_MODEL=gemini-2.5-flash
+LLM_GROUNDED_ANSWER_MODEL=gemini-2.5-flash
+LLM_EXTRACTION_MODEL=gemini-2.5-flash
 COPILOTE_MODEL=gpt-4o-mini
 
 EXTRACT_INPUT_PATH='../data/processed_bible.json'

--- a/search-engine/src/__tests__/llm-factory.test.ts
+++ b/search-engine/src/__tests__/llm-factory.test.ts
@@ -146,6 +146,17 @@ describe("llm factory", () => {
     expect(response.provider).toBe("gemini");
   });
 
+  it("defaults to Gemini 2.5 when provider and model are omitted", () => {
+    process.env.GEMINI_API_KEY = "gemini-key";
+
+    const resolved = resolveAndValidateLlmClientOptions({
+      purpose: "chat",
+    });
+
+    expect(resolved.provider).toBe("gemini");
+    expect(resolved.model).toBe("gemini-2.5-flash");
+  });
+
   it("infers the provider from explicit secrets when provider is omitted", async () => {
     registerLlmProvider(createMockProvider("openai"));
 

--- a/search-engine/src/__tests__/llm-providers.test.ts
+++ b/search-engine/src/__tests__/llm-providers.test.ts
@@ -138,4 +138,30 @@ describe("llm providers", () => {
     expect(response.provider).toBe("gemini");
     expect(response.content).toBe("gemini response");
   });
+
+  it("normalizes prefixed Gemini model names before calling generateContent", async () => {
+    process.env.GEMINI_API_KEY = "gemini-key";
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: "gemini response" }] } }],
+      }),
+    });
+    registerDefaultLlmProviders();
+
+    const client = await createLlmClient({
+      purpose: "chat",
+      provider: "gemini",
+      model: "models/gemini-2.5-flash",
+    });
+
+    await client.complete({
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=gemini-key",
+      expect.any(Object)
+    );
+  });
 });

--- a/search-engine/src/__tests__/llm-resilience.test.ts
+++ b/search-engine/src/__tests__/llm-resilience.test.ts
@@ -57,6 +57,13 @@ describe("llm resilience", () => {
     expect(resolveProviderOrder("chat")).toEqual(["openai", "gemini", "ollama"]);
   });
 
+  it("defaults to Gemini-first fallback order for supported workloads", () => {
+    expect(resolveProviderOrder("chat")).toEqual(["gemini", "openai", "copilot", "ollama"]);
+    expect(resolveProviderOrder("router")).toEqual(["gemini", "openai", "copilot", "ollama"]);
+    expect(resolveProviderOrder("grounded-answer")).toEqual(["gemini", "openai", "copilot", "ollama"]);
+    expect(resolveProviderOrder("extraction")).toEqual(["gemini", "openai", "copilot", "ollama"]);
+  });
+
   it("classifies upstream rate-limit errors", () => {
     expect(classifyLlmError({ statusCode: 429 })).toBe("rate-limit");
     expect(classifyLlmError(new Error("Too many requests from upstream"))).toBe("rate-limit");

--- a/search-engine/src/lib/llm/env.ts
+++ b/search-engine/src/lib/llm/env.ts
@@ -23,7 +23,7 @@ const PURPOSE_MODEL_ENV_KEYS: Record<LlmPurpose, string[]> = {
 const PROVIDER_DEFAULT_MODELS: Record<LlmProviderName, string> = {
   copilot: "gpt-4o-mini",
   openai: "gpt-4o-mini",
-  gemini: "gemini-2.0-flash",
+  gemini: "gemini-2.5-flash",
   ollama: "llama3.2",
 };
 
@@ -76,7 +76,7 @@ export function resolveLlmProvider(options: LlmClientOptions): LlmProviderName {
     options.provider ??
     resolveProviderFromEnv(options.purpose) ??
     inferProviderFromSecrets(options.secrets) ??
-    "copilot"
+    "gemini"
   );
 }
 

--- a/search-engine/src/lib/llm/providers/gemini.ts
+++ b/search-engine/src/lib/llm/providers/gemini.ts
@@ -17,8 +17,13 @@ type GeminiResponse = {
   candidates?: GeminiCandidate[];
 };
 
+function normalizeGeminiModel(model: string): string {
+  const trimmedModel = model.trim();
+  return trimmedModel.startsWith("models/") ? trimmedModel.slice("models/".length) : trimmedModel;
+}
+
 function buildGeminiUrl(model: string, apiKey: string): string {
-  const encodedModel = encodeURIComponent(model);
+  const encodedModel = encodeURIComponent(normalizeGeminiModel(model));
   return `https://generativelanguage.googleapis.com/v1beta/models/${encodedModel}:generateContent?key=${apiKey}`;
 }
 

--- a/search-engine/src/lib/llm/resilience.ts
+++ b/search-engine/src/lib/llm/resilience.ts
@@ -5,10 +5,10 @@ const DEFAULT_FAILURE_THRESHOLD = 3;
 const DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;
 
 const DEFAULT_PROVIDER_ORDER: Record<LlmPurpose, LlmProviderName[]> = {
-  chat: ["copilot", "openai", "gemini", "ollama"],
-  router: ["copilot", "openai", "ollama"],
-  "grounded-answer": ["copilot", "openai", "gemini", "ollama"],
-  extraction: ["copilot", "openai", "ollama"],
+  chat: ["gemini", "openai", "copilot", "ollama"],
+  router: ["gemini", "openai", "copilot", "ollama"],
+  "grounded-answer": ["gemini", "openai", "copilot", "ollama"],
+  extraction: ["gemini", "openai", "copilot", "ollama"],
 };
 
 type CircuitState = {


### PR DESCRIPTION
## Summary
- default the shared LLM factory to Gemini with `gemini-2.5-flash`
- normalize Gemini model names before building the Gemini REST path to avoid `models/models%2F...` 404s
- move built-in fallback chains and docs/examples to Gemini-first defaults
- add regression tests for default resolution, Gemini URL normalization, and Gemini-first fallback order

## Testing
- npm run test:run -- src/__tests__/llm-factory.test.ts src/__tests__/llm-providers.test.ts src/__tests__/llm-resilience.test.ts

Closes #76