### PR TITLE
Fix comma-separated chat citation formatting

### DIFF
--- a/search-engine/src/__tests__/message-formatting.service.test.tsx
+++ b/search-engine/src/__tests__/message-formatting.service.test.tsx
@@ -47,4 +47,21 @@ describe("message formatting service", () => {
     fireEvent.click(screen.getByRole("button", { name: "John 3:16" }));
     expect(onCitationClick).toHaveBeenCalledWith("John 3:16");
   });
+
+  it("splits comma-separated citations inside a single bracket group", () => {
+    const onCitationClick = vi.fn();
+    const text =
+      "D'apres les Ecritures, les disciples incluent [Matthieu 5:1, Matthieu 21:6, Marc 3:7].";
+
+    render(<div>{renderMessageWithCitations(text, onCitationClick)}</div>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Matthieu 5:1" }));
+    fireEvent.click(screen.getByRole("button", { name: "Matthieu 21:6" }));
+    fireEvent.click(screen.getByRole("button", { name: "Marc 3:7" }));
+
+    expect(onCitationClick).toHaveBeenCalledTimes(3);
+    expect(onCitationClick).toHaveBeenNthCalledWith(1, "Matthieu 5:1");
+    expect(onCitationClick).toHaveBeenNthCalledWith(2, "Matthieu 21:6");
+    expect(onCitationClick).toHaveBeenNthCalledWith(3, "Marc 3:7");
+  });
 });

--- a/search-engine/src/app/services/messageFormatting.tsx
+++ b/search-engine/src/app/services/messageFormatting.tsx
@@ -6,7 +6,7 @@ const TOKEN_REGEX = /(\[([^\]]+\d+:\d+(?:-\d+)?)\]|\(([^\)]+\d+:\d+(?:-\d+)?)\)|
 
 function splitCitationReferences(citation: string): string[] {
   const refs = citation
-    .split(/\s*;\s*/)
+    .split(/\s*[;,]\s*/)
     .map((item) => item.trim())
     .filter((item) => item.length > 0 && /\d+:\d+/.test(item));
 
@@ -69,7 +69,7 @@ export const renderMessageWithCitations: RenderMessageWithCitations = (
       <Fragment key={`cite-group-${citation}-${index}`}>
         {references.map((reference, refIndex) => (
           <Fragment key={`cite-item-${reference}-${refIndex}`}>
-            {refIndex > 0 ? "; " : null}
+            {refIndex > 0 ? ", " : null}
             <button
               type="button"
               onClick={() => onCitationClick(reference)}


### PR DESCRIPTION
## Summary
- split grouped inline citations on commas as well as semicolons
- keep grouped citation rendering aligned with comma-separated Bible references
- add regression coverage for comma-separated bracketed references

## Testing
- npm run test:run -- src/__tests__/message-formatting.service.test.tsx src/__tests__/chat-message-list.integration.test.tsx

Closes #78