### PR TITLE
Fix chat fallback and graph entity preview

### DIFF
--- a/search-engine/env.example
+++ b/search-engine/env.example
@@ -28,7 +28,7 @@ LLM_CHAT_MODEL=gemini-2.5-flash
 LLM_ROUTER_MODEL=gemini-2.5-flash
 LLM_GROUNDED_ANSWER_MODEL=gemini-2.5-flash
 LLM_EXTRACTION_MODEL=gemini-2.5-flash
-COPILOTE_MODEL=gpt-4o-mini
+COPILOT_MODEL=gpt-4o-mini
 
 EXTRACT_INPUT_PATH='../data/processed_bible.json'
 EXTRACT_OUTPUT_PATH='../data/raw_graph.enrich.json'

--- a/search-engine/package.json
+++ b/search-engine/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
+    "dev:turbo": "next dev",
     "build": "next build",
     "start": "next start",
     "extract:graph": "tsx src/scripts/extract-graph.ts",

--- a/search-engine/src/__tests__/extract-graph.test.ts
+++ b/search-engine/src/__tests__/extract-graph.test.ts
@@ -744,7 +744,7 @@ describe('US-005 - LLM Extraction Pipeline', () => {
     }, 15000)
 
     it('uses gpt-4o-mini by default', () => {
-      const model = process.env.COPILOTE_MODEL ?? 'gpt-4o-mini'
+      const model = process.env.COPILOT_MODEL ?? 'gpt-4o-mini'
       expect(model).toBe('gpt-4o-mini')
     })
 

--- a/search-engine/src/__tests__/graph-query.test.ts
+++ b/search-engine/src/__tests__/graph-query.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { extractGraphEntityQuery } from "../app/services/graphQuery";
+
+describe("extractGraphEntityQuery", () => {
+  it("extracts the subject from french who-is questions", () => {
+    expect(extractGraphEntityQuery("Qui est David?"))?.toBe("David");
+  });
+
+  it("extracts the subject from english who-is questions", () => {
+    expect(extractGraphEntityQuery("Who is Jesus?"))?.toBe("Jesus");
+  });
+
+  it("returns null when there is no recognizable subject pattern", () => {
+    expect(extractGraphEntityQuery("Donne-moi un resume de 1 Samuel 17")).toBeNull();
+  });
+});

--- a/search-engine/src/__tests__/llm-factory.test.ts
+++ b/search-engine/src/__tests__/llm-factory.test.ts
@@ -17,7 +17,6 @@ const envSnapshot = {
   LLM_CHAT_MODEL: process.env.LLM_CHAT_MODEL,
   QUERY_ROUTER_MODEL: process.env.QUERY_ROUTER_MODEL,
   GROUNDED_ANSWER_MODEL: process.env.GROUNDED_ANSWER_MODEL,
-  COPILOTE_MODEL: process.env.COPILOTE_MODEL,
   COPILOT_MODEL: process.env.COPILOT_MODEL,
 };
 
@@ -64,7 +63,6 @@ describe("llm factory", () => {
     delete process.env.LLM_CHAT_MODEL;
     delete process.env.QUERY_ROUTER_MODEL;
     delete process.env.GROUNDED_ANSWER_MODEL;
-    delete process.env.COPILOTE_MODEL;
     delete process.env.COPILOT_MODEL;
   });
 
@@ -79,13 +77,12 @@ describe("llm factory", () => {
     restoreEnv("LLM_CHAT_MODEL", envSnapshot.LLM_CHAT_MODEL);
     restoreEnv("QUERY_ROUTER_MODEL", envSnapshot.QUERY_ROUTER_MODEL);
     restoreEnv("GROUNDED_ANSWER_MODEL", envSnapshot.GROUNDED_ANSWER_MODEL);
-    restoreEnv("COPILOTE_MODEL", envSnapshot.COPILOTE_MODEL);
     restoreEnv("COPILOT_MODEL", envSnapshot.COPILOT_MODEL);
   });
 
-  it("resolves legacy extraction model aliases", () => {
+  it("resolves the copilot extraction model from the canonical env", () => {
     process.env.GITHUB_TOKEN = "github-token";
-    process.env.COPILOTE_MODEL = "gpt-4o-mini-custom";
+    process.env.COPILOT_MODEL = "gpt-4o-mini-custom";
 
     const resolved = resolveAndValidateLlmClientOptions({
       purpose: "extraction",

--- a/search-engine/src/__tests__/llm-factory.test.ts
+++ b/search-engine/src/__tests__/llm-factory.test.ts
@@ -13,6 +13,8 @@ const envSnapshot = {
   GEMINI_API_KEY: process.env.GEMINI_API_KEY,
   OLLAMA_BASE_URL: process.env.OLLAMA_BASE_URL,
   LLM_DEFAULT_PROVIDER: process.env.LLM_DEFAULT_PROVIDER,
+  LLM_CHAT_PROVIDER: process.env.LLM_CHAT_PROVIDER,
+  LLM_CHAT_MODEL: process.env.LLM_CHAT_MODEL,
   QUERY_ROUTER_MODEL: process.env.QUERY_ROUTER_MODEL,
   GROUNDED_ANSWER_MODEL: process.env.GROUNDED_ANSWER_MODEL,
   COPILOTE_MODEL: process.env.COPILOTE_MODEL,
@@ -58,6 +60,8 @@ describe("llm factory", () => {
     delete process.env.GEMINI_API_KEY;
     delete process.env.OLLAMA_BASE_URL;
     delete process.env.LLM_DEFAULT_PROVIDER;
+    delete process.env.LLM_CHAT_PROVIDER;
+    delete process.env.LLM_CHAT_MODEL;
     delete process.env.QUERY_ROUTER_MODEL;
     delete process.env.GROUNDED_ANSWER_MODEL;
     delete process.env.COPILOTE_MODEL;
@@ -71,6 +75,8 @@ describe("llm factory", () => {
     restoreEnv("GEMINI_API_KEY", envSnapshot.GEMINI_API_KEY);
     restoreEnv("OLLAMA_BASE_URL", envSnapshot.OLLAMA_BASE_URL);
     restoreEnv("LLM_DEFAULT_PROVIDER", envSnapshot.LLM_DEFAULT_PROVIDER);
+    restoreEnv("LLM_CHAT_PROVIDER", envSnapshot.LLM_CHAT_PROVIDER);
+    restoreEnv("LLM_CHAT_MODEL", envSnapshot.LLM_CHAT_MODEL);
     restoreEnv("QUERY_ROUTER_MODEL", envSnapshot.QUERY_ROUTER_MODEL);
     restoreEnv("GROUNDED_ANSWER_MODEL", envSnapshot.GROUNDED_ANSWER_MODEL);
     restoreEnv("COPILOTE_MODEL", envSnapshot.COPILOTE_MODEL);
@@ -155,6 +161,20 @@ describe("llm factory", () => {
 
     expect(resolved.provider).toBe("gemini");
     expect(resolved.model).toBe("gemini-2.5-flash");
+  });
+
+  it("does not leak purpose model to a different explicit provider", () => {
+    process.env.LLM_CHAT_PROVIDER = "gemini";
+    process.env.LLM_CHAT_MODEL = "gemini-2.5-flash";
+    process.env.OPENAI_API_KEY = "openai-key";
+
+    const resolved = resolveAndValidateLlmClientOptions({
+      purpose: "chat",
+      provider: "openai",
+    });
+
+    expect(resolved.provider).toBe("openai");
+    expect(resolved.model).toBe("gpt-4o-mini");
   });
 
   it("infers the provider from explicit secrets when provider is omitted", async () => {

--- a/search-engine/src/__tests__/llm-providers.test.ts
+++ b/search-engine/src/__tests__/llm-providers.test.ts
@@ -164,4 +164,32 @@ describe("llm providers", () => {
       expect.any(Object)
     );
   });
+
+  it("normalizes leading-slash Gemini model names in URL and body", async () => {
+    process.env.GEMINI_API_KEY = "gemini-key";
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: "gemini response" }] } }],
+      }),
+    });
+    registerDefaultLlmProviders();
+
+    const client = await createLlmClient({
+      purpose: "chat",
+      provider: "gemini",
+      model: "/gemini-2.5-flash",
+    });
+
+    await client.complete({
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=gemini-key",
+      expect.objectContaining({
+        body: expect.stringContaining('"model":"gemini-2.5-flash"'),
+      })
+    );
+  });
 });

--- a/search-engine/src/__tests__/llm-resilience.test.ts
+++ b/search-engine/src/__tests__/llm-resilience.test.ts
@@ -69,6 +69,16 @@ describe("llm resilience", () => {
     expect(classifyLlmError(new Error("Too many requests from upstream"))).toBe("rate-limit");
   });
 
+  it("classifies not-found model errors as retryable server errors", () => {
+    expect(classifyLlmError({ statusCode: 404 })).toBe("server-error");
+    expect(classifyLlmError(new Error("Unknown model: gemini-2.5-flash"))).toBe("server-error");
+  });
+
+  it("classifies unauthorized errors as retryable server errors", () => {
+    expect(classifyLlmError({ statusCode: 401 })).toBe("server-error");
+    expect(classifyLlmError(new Error("401 Unauthorized"))).toBe("server-error");
+  });
+
   it("falls back to the next provider on rate-limit failure", async () => {
     registerLlmProvider(
       createProvider("copilot", async () => {

--- a/search-engine/src/app/api/chat/route.ts
+++ b/search-engine/src/app/api/chat/route.ts
@@ -13,7 +13,8 @@ import {
 } from "@search/lib/context-injection";
 
 const UNKNOWN_RESPONSE = "Je ne sais pas d'après les Écritures fournies.";
-const DEFAULT_MODEL = process.env.GROUNDED_ANSWER_MODEL ?? "gpt-4o-mini";
+const CHAT_TIMEOUT_MS = Number(process.env.LLM_CHAT_TIMEOUT_MS ?? "30000");
+const CHAT_EXECUTION_TIMEOUT_MS = Number(process.env.LLM_CHAT_EXEC_TIMEOUT_MS ?? "35000");
 
 registerDefaultLlmProviders();
 
@@ -128,7 +129,17 @@ function extractUpstreamRateLimit(error: unknown): { retryAfterSeconds: number }
   return null;
 }
 
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms.`)), timeoutMs);
+    }),
+  ]);
+}
+
 export async function POST(req: NextRequest): Promise<Response> {
+  const traceId = `chat-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
   const rateLimitResult = rateLimit(req);
   if (!rateLimitResult.success) {
     return NextResponse.json(
@@ -169,7 +180,16 @@ export async function POST(req: NextRequest): Promise<Response> {
   }
 
   try {
+    console.info("[chat][trace] start", { traceId, query });
     const routing = await routeQuery({ query });
+    console.info("[chat][trace] routed", {
+      traceId,
+      intent: routing.intent,
+      k: routing.k,
+      vectorWeight: routing.vectorWeight,
+      graphWeight: routing.graphWeight,
+      bm25Weight: routing.bm25Weight,
+    });
     const db = await getDb();
     const retriever = new HybridRetriever(db);
     const retrievalResult = await retriever.retrieve(
@@ -182,6 +202,12 @@ export async function POST(req: NextRequest): Promise<Response> {
     );
 
     const context = assembleHybridContext(retrievalResult.verses, retrievalResult.entityFacts);
+    console.info("[chat][trace] retrieved", {
+      traceId,
+      verses: retrievalResult.verses.length,
+      entityFacts: retrievalResult.entityFacts.length,
+      references: context.references.length,
+    });
     if (!context.references.length) {
       return createStaticAssistantResponse(UNKNOWN_RESPONSE);
     }
@@ -189,18 +215,22 @@ export async function POST(req: NextRequest): Promise<Response> {
     const stream = createUIMessageStream({
       execute: async ({ writer }) => {
         const textId = "chat-response";
+        console.info("[chat][trace] stream-execute", { traceId, textId });
 
         writer.write({ type: "text-start", id: textId });
         try {
-          await executeWithFallback({
+          const executionTimeoutMs = Number.isFinite(CHAT_EXECUTION_TIMEOUT_MS) && CHAT_EXECUTION_TIMEOUT_MS > 0
+            ? CHAT_EXECUTION_TIMEOUT_MS
+            : 35000;
+
+          await withTimeout(executeWithFallback({
             clientOptions: {
               purpose: "chat",
-              model: DEFAULT_MODEL,
+              timeoutMs: Number.isFinite(CHAT_TIMEOUT_MS) && CHAT_TIMEOUT_MS > 0 ? CHAT_TIMEOUT_MS : 30000,
             },
             execute: async (client) => {
               if (client.stream) {
                 for await (const token of client.stream({
-                  model: DEFAULT_MODEL,
                   temperature: 0,
                   messages: [
                     { role: "system", content: buildGroundedStreamingSystemPrompt() },
@@ -221,7 +251,6 @@ export async function POST(req: NextRequest): Promise<Response> {
               }
 
               const response = await client.complete({
-                model: DEFAULT_MODEL,
                 temperature: 0,
                 messages: [
                   { role: "system", content: buildGroundedStreamingSystemPrompt() },
@@ -241,7 +270,7 @@ export async function POST(req: NextRequest): Promise<Response> {
                 writer.write({ type: "text-delta", id: textId, delta: response.content });
               }
             },
-          });
+          }), executionTimeoutMs, "Chat execution");
         } finally {
           writer.write({ type: "text-end", id: textId });
         }

--- a/search-engine/src/app/page.tsx
+++ b/search-engine/src/app/page.tsx
@@ -12,6 +12,7 @@ import { COPY, LOCALE_STORAGE_KEY, resolveLocale } from "./services/localization
 import { parseRetryAfterSeconds, extractRetryAfterFromMessage } from "./services/rateLimitParser";
 import { getMessageText, renderMessageWithCitations } from "./services/messageFormatting";
 import { buildRelationSnippets } from "./services/relationSnippets";
+import { extractGraphEntityQuery } from "./services/graphQuery";
 
 export default function Home() {
   const [locale, setLocale] = useState<Locale>("en");
@@ -117,18 +118,29 @@ export default function Home() {
     setGraphError(null);
 
     try {
-      const res = await fetch("/api/hybrid-search", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ query }),
-      });
+      const runGraphSearch = async (searchQuery: string) => {
+        const res = await fetch("/api/hybrid-search", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ query: searchQuery }),
+        });
 
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body?.error ?? uiText.graphLoadError);
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body?.error ?? uiText.graphLoadError);
+        }
+
+        return (await res.json()) as HybridSearchResponse;
+      };
+
+      let body = await runGraphSearch(query);
+      if (!Array.isArray(body.entityFacts) || body.entityFacts.length === 0) {
+        const fallbackQuery = extractGraphEntityQuery(query);
+        if (fallbackQuery && fallbackQuery.toLowerCase() !== query.trim().toLowerCase()) {
+          body = await runGraphSearch(fallbackQuery);
+        }
       }
 
-      const body = (await res.json()) as HybridSearchResponse;
       setEntityFacts(Array.isArray(body.entityFacts) ? body.entityFacts.slice(0, 10) : []);
     } catch (e) {
       const message = e instanceof Error ? e.message : uiText.unknownError;
@@ -169,9 +181,8 @@ export default function Home() {
     if (!trimmed || !canSubmit) return;
 
     setDraft("");
-    const graphPromise = loadGraphPreview(trimmed);
+    void loadGraphPreview(trimmed);
     await sendMessage({ text: trimmed });
-    await graphPromise;
   }
 
   async function onEntityChipClick(entityName: string) {
@@ -179,9 +190,8 @@ export default function Home() {
     if (!query || !canSubmit) return;
 
     setDraft("");
-    const graphPromise = loadGraphPreview(query);
+    void loadGraphPreview(query);
     await sendMessage({ text: query });
-    await graphPromise;
   }
 
   return (

--- a/search-engine/src/app/services/graphQuery.ts
+++ b/search-engine/src/app/services/graphQuery.ts
@@ -1,0 +1,29 @@
+function trimTrailingPunctuation(value: string): string {
+  return value.trim().replace(/[?!.,;:]+$/g, "").trim();
+}
+
+export function extractGraphEntityQuery(query: string): string | null {
+  const normalized = trimTrailingPunctuation(query);
+
+  if (!normalized) {
+    return null;
+  }
+
+  const patterns = [
+    /^qui est\s+(.+)$/i,
+    /^who is\s+(.+)$/i,
+    /^parle[- ]moi de\s+(.+)$/i,
+    /^tell me about\s+(.+)$/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = normalized.match(pattern);
+    const candidate = trimTrailingPunctuation(match?.[1] ?? "");
+
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return null;
+}

--- a/search-engine/src/lib/llm/env.ts
+++ b/search-engine/src/lib/llm/env.ts
@@ -102,7 +102,10 @@ export function resolveLlmModel(provider: LlmProviderName, purpose: LlmPurpose, 
   if (providerSpecific) return providerSpecific;
 
   const purposeSpecific = readFirstEnv(PURPOSE_MODEL_ENV_KEYS[purpose]);
-  if (purposeSpecific) return purposeSpecific;
+  const configuredProviderForPurpose = resolveProviderFromEnv(purpose);
+  if (purposeSpecific && (!configuredProviderForPurpose || configuredProviderForPurpose === provider)) {
+    return purposeSpecific;
+  }
 
   const genericProvider = readFirstEnv([
     `${provider.toUpperCase()}_MODEL`,

--- a/search-engine/src/lib/llm/env.ts
+++ b/search-engine/src/lib/llm/env.ts
@@ -17,7 +17,7 @@ const PURPOSE_MODEL_ENV_KEYS: Record<LlmPurpose, string[]> = {
   chat: ["LLM_CHAT_MODEL", "GROUNDED_ANSWER_MODEL"],
   router: ["LLM_ROUTER_MODEL", "QUERY_ROUTER_MODEL"],
   "grounded-answer": ["LLM_GROUNDED_ANSWER_MODEL", "GROUNDED_ANSWER_MODEL"],
-  extraction: ["LLM_EXTRACTION_MODEL", "COPILOT_MODEL", "COPILOTE_MODEL"],
+  extraction: ["LLM_EXTRACTION_MODEL", "COPILOT_MODEL"],
 };
 
 const PROVIDER_DEFAULT_MODELS: Record<LlmProviderName, string> = {
@@ -107,10 +107,7 @@ export function resolveLlmModel(provider: LlmProviderName, purpose: LlmPurpose, 
     return purposeSpecific;
   }
 
-  const genericProvider = readFirstEnv([
-    `${provider.toUpperCase()}_MODEL`,
-    provider === "copilot" ? "COPILOTE_MODEL" : "",
-  ].filter(Boolean));
+  const genericProvider = readFirstEnv([`${provider.toUpperCase()}_MODEL`]);
   if (genericProvider) return genericProvider;
 
   return PROVIDER_DEFAULT_MODELS[provider];

--- a/search-engine/src/lib/llm/providers/gemini.ts
+++ b/search-engine/src/lib/llm/providers/gemini.ts
@@ -17,9 +17,16 @@ type GeminiResponse = {
   candidates?: GeminiCandidate[];
 };
 
+type GeminiError = Error & {
+  statusCode?: number;
+  responseHeaders?: Headers;
+};
+
+const DEFAULT_GEMINI_TIMEOUT_MS = 30_000;
+
 function normalizeGeminiModel(model: string): string {
   const trimmedModel = model.trim();
-  return trimmedModel.startsWith("models/") ? trimmedModel.slice("models/".length) : trimmedModel;
+  return trimmedModel.replace(/^\/+/, "").replace(/^models\/+/, "");
 }
 
 function buildGeminiUrl(model: string, apiKey: string): string {
@@ -36,6 +43,7 @@ function toGeminiRequest(
   model: string,
   responseMimeType?: string
 ): RequestInit {
+  const normalizedModel = normalizeGeminiModel(model);
   const systemMessage = request.messages.find((message) => message.role === "system");
 
   return {
@@ -60,7 +68,7 @@ function toGeminiRequest(
           role: message.role === "assistant" ? "model" : "user",
           parts: [{ text: message.content }],
         })),
-      model,
+      model: normalizedModel,
     }),
   };
 }
@@ -69,21 +77,62 @@ function extractGeminiText(response: GeminiResponse): string {
   return response.candidates?.[0]?.content?.parts?.map((part) => part.text ?? "").join("").trim() ?? "";
 }
 
+function createGeminiHttpError(response: Response): GeminiError {
+  const error = new Error(`Gemini request failed with status ${response.status}.`) as GeminiError;
+  error.statusCode = response.status;
+  error.responseHeaders = response.headers;
+  return error;
+}
+
+async function fetchGemini(
+  url: string,
+  init: RequestInit,
+  timeoutMs?: number
+): Promise<Response> {
+  const effectiveTimeoutMs = timeoutMs && timeoutMs > 0 ? timeoutMs : DEFAULT_GEMINI_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), effectiveTimeoutMs);
+
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const isAbort =
+      (error instanceof DOMException && error.name === "AbortError") ||
+      (typeof error === "object" && error !== null && "name" in error && (error as { name?: string }).name === "AbortError");
+
+    if (isAbort) {
+      throw new Error(`Gemini request timeout after ${effectiveTimeoutMs}ms.`);
+    }
+
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function createGeminiClient(options: ResolvedLlmClientOptions): LlmClient {
   return {
     async complete(request: LlmCompletionRequest): Promise<LlmCompletionResponse> {
       const model = request.model ?? options.model;
+      const normalizedModel = normalizeGeminiModel(model);
       const apiKey = options.secrets.geminiApiKey ?? options.secrets.apiKey ?? "";
-      const response = await fetch(buildGeminiUrl(model, apiKey), toGeminiBody(request, model));
+      const response = await fetchGemini(
+        buildGeminiUrl(model, apiKey),
+        toGeminiBody(request, model),
+        options.timeoutMs
+      );
 
       if (!response.ok) {
-        throw new Error(`Gemini request failed with status ${response.status}.`);
+        throw createGeminiHttpError(response);
       }
 
       const payload = (await response.json()) as GeminiResponse;
       return {
         content: extractGeminiText(payload),
-        model,
+        model: normalizedModel,
         provider: "gemini",
         raw: payload,
       };
@@ -92,13 +141,14 @@ function createGeminiClient(options: ResolvedLlmClientOptions): LlmClient {
     async completeJson<T>(request: LlmJsonRequest): Promise<T> {
       const model = request.model ?? options.model;
       const apiKey = options.secrets.geminiApiKey ?? options.secrets.apiKey ?? "";
-      const rawResponse = await fetch(
+      const rawResponse = await fetchGemini(
         buildGeminiUrl(model, apiKey),
-        toGeminiRequest(request, model, "application/json")
+        toGeminiRequest(request, model, "application/json"),
+        options.timeoutMs
       );
 
       if (!rawResponse.ok) {
-        throw new Error(`Gemini request failed with status ${rawResponse.status}.`);
+        throw createGeminiHttpError(rawResponse);
       }
 
       const payload = (await rawResponse.json()) as GeminiResponse;

--- a/search-engine/src/lib/llm/providers/openai-compatible.ts
+++ b/search-engine/src/lib/llm/providers/openai-compatible.ts
@@ -19,6 +19,24 @@ type OpenAICompatibleConfig = {
   resolveApiKey: (options: ResolvedLlmClientOptions) => string;
 };
 
+const DEFAULT_STREAM_TIMEOUT_MS = 30_000;
+
+async function readWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  provider: LlmProviderName
+): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(
+        () => reject(new Error(`Provider ${provider} stream timeout after ${timeoutMs}ms.`)),
+        timeoutMs
+      );
+    }),
+  ]);
+}
+
 function toOpenAIMessages(messages: LlmMessage[]): Array<{ role: LlmMessage["role"]; content: string }> {
   return messages.map((message) => ({
     role: message.role,
@@ -70,6 +88,7 @@ function createOpenAICompatibleClient(
 
     async *stream(request: LlmCompletionRequest): AsyncIterable<string> {
       const model = request.model ?? options.model;
+      const streamTimeoutMs = options.timeoutMs && options.timeoutMs > 0 ? options.timeoutMs : DEFAULT_STREAM_TIMEOUT_MS;
       const stream = await client.chat.completions.create({
         model,
         temperature: request.temperature ?? 0,
@@ -78,7 +97,14 @@ function createOpenAICompatibleClient(
         messages: toOpenAIMessages(request.messages),
       });
 
-      for await (const chunk of stream) {
+      const iterator = stream[Symbol.asyncIterator]();
+      while (true) {
+        const next = await readWithTimeout(iterator.next(), streamTimeoutMs, config.provider);
+        if (next.done) {
+          break;
+        }
+
+        const chunk = next.value;
         const token = chunk.choices[0]?.delta?.content;
         if (token) yield token;
       }

--- a/search-engine/src/lib/llm/resilience.ts
+++ b/search-engine/src/lib/llm/resilience.ts
@@ -68,6 +68,14 @@ export function classifyLlmError(error: unknown): ProviderErrorType {
   const message = `${(error as { message?: string })?.message ?? ""}`.toLowerCase();
   const statusCode = (error as { statusCode?: number })?.statusCode;
 
+  if (statusCode === 401 || statusCode === 403 || message.includes("unauthorized") || message.includes("forbidden")) {
+    return "server-error";
+  }
+
+  if (statusCode === 404 || message.includes("not found") || message.includes("unknown model")) {
+    return "server-error";
+  }
+
   if (statusCode === 429 || message.includes("too many requests") || message.includes("rate limit")) {
     return "rate-limit";
   }
@@ -130,7 +138,11 @@ export async function executeWithFallback<T>(
     }
 
     try {
-      const client = await createLlmClient({ ...options.clientOptions, provider });
+      const client = await createLlmClient({
+        ...options.clientOptions,
+        provider,
+        model: index === 0 ? options.clientOptions.model : undefined,
+      });
       const result = await options.execute(client, provider);
       recordProviderSuccess(provider);
       return { provider, result, failovers };

--- a/search-engine/src/lib/mongodb.ts
+++ b/search-engine/src/lib/mongodb.ts
@@ -2,6 +2,7 @@ import { MongoClient, Db } from "mongodb";
 
 const MONGODB_URI = process.env.DATABASE_URL;
 const DB_NAME = process.env.MONGODB_DB_NAME ?? "bible_sg";
+const MONGODB_CONNECT_TIMEOUT_MS = Number(process.env.MONGODB_CONNECT_TIMEOUT_MS ?? "5000");
 
 if (!MONGODB_URI) {
   throw new Error("Missing DATABASE_URL environment variable.");
@@ -12,11 +13,23 @@ declare global {
   var __mongoClientPromise: Promise<MongoClient> | undefined;
 }
 
-const client = new MongoClient(MONGODB_URI);
+const timeoutMs = Number.isFinite(MONGODB_CONNECT_TIMEOUT_MS) && MONGODB_CONNECT_TIMEOUT_MS > 0
+  ? MONGODB_CONNECT_TIMEOUT_MS
+  : 5000;
+
+const client = new MongoClient(MONGODB_URI, {
+  serverSelectionTimeoutMS: timeoutMs,
+  connectTimeoutMS: timeoutMs,
+});
 const clientPromise =
   global.__mongoClientPromise ?? (global.__mongoClientPromise = client.connect());
 
 export async function getDb(): Promise<Db> {
-  const connectedClient = await clientPromise;
+  const connectedClient = await Promise.race([
+    clientPromise,
+    new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error(`MongoDB connection timeout after ${timeoutMs}ms.`)), timeoutMs);
+    }),
+  ]);
   return connectedClient.db(DB_NAME);
 }

--- a/search-engine/src/scripts/extract-graph.ts
+++ b/search-engine/src/scripts/extract-graph.ts
@@ -1196,7 +1196,7 @@ export async function main(): Promise<void> {
     .filter(Boolean) as TargetBook[]
 
   const delayMs = Number(process.env.EXTRACT_DELAY_MS ?? '20000')
-  const model = process.env.COPILOTE_MODEL ?? 'gpt-4o-mini'
+  const model = process.env.COPILOT_MODEL ?? 'gpt-4o-mini'
 
   if (process.env.VERBOSE !== 'false') {
     console.log(`[extract-graph] config: model=${model}, delayMs=${delayMs}ms`)


### PR DESCRIPTION
## Summary
- make webpack the default dev mode to avoid the unstable Turbopack path during local debugging
- harden chat fallback behavior for provider/model errors and add request timeouts for chat, Gemini, OpenAI-compatible streaming, and MongoDB connection setup
- decouple graph preview loading from chat submission and retry graph lookup with the extracted entity name for questions like `Qui est David?`

## Validation
- `npm run test:run -- src/__tests__/chat-route.test.ts src/__tests__/llm-factory.test.ts src/__tests__/llm-providers.test.ts src/__tests__/llm-resilience.test.ts src/__tests__/graph-query.test.ts`
- 29 tests passed

## Notes
- keeps the temporary chat trace logs in place for runtime verification while the flow is being stabilized