### PR TITLE
Fix duplicate submit workload by sequencing graph preview after chat

### DIFF
--- a/search-engine/src/app/page.tsx
+++ b/search-engine/src/app/page.tsx
@@ -181,8 +181,8 @@ export default function Home() {
     if (!trimmed || !canSubmit) return;
 
     setDraft("");
-    void loadGraphPreview(trimmed);
     await sendMessage({ text: trimmed });
+    await loadGraphPreview(trimmed);
   }
 
   async function onEntityChipClick(entityName: string) {
@@ -190,8 +190,8 @@ export default function Home() {
     if (!query || !canSubmit) return;
 
     setDraft("");
-    void loadGraphPreview(query);
     await sendMessage({ text: query });
+    await loadGraphPreview(query);
   }
 
   return (


### PR DESCRIPTION
## Summary
- stop firing `/api/hybrid-search` in parallel with `/api/chat` on submit
- sequence graph preview fetch to run after chat send completes
- apply the same sequencing for entity chip submissions

## Why
- removes duplicate concurrent workload for the same query
- reduces contention and noise in perf logs while keeping graph preview behavior

## Validation
- `npx vitest run src/__tests__/chat-route.test.ts src/__tests__/hybrid-search.test.ts`
- Result: 2 files passed, 11 tests passed

## Risk
- Low. Small UI flow change only in submit handlers.
