### PR TITLE
docs(openapi): translate query examples to French

### DIFF
--- a/docs/architecture-rag-graph-router.md
+++ b/docs/architecture-rag-graph-router.md
@@ -5,7 +5,7 @@
 The Bible Search Engine combines three interacting systems to deliver accurate, contextualized biblical answers:
 
 1. **Query Router (US-009)**: Intent classification + adaptive parameter tuning
-2. **Hybrid Retriever**: Vector + Graph search with adaptive fanout
+2. **Hybrid Retriever**: Vector + Graph + BM25 search with adaptive fanout
 3. **Context Injection & Grounded Answer (US-010)**: LLM-based answer generation with citation enforcement
 4. **Streaming API (US-011)**: Real-time token streaming to frontend
 
@@ -24,11 +24,11 @@ graph TD
     B2 -->|resolve context| C
     
     C -->|heuristic + LLM| D["Intent Classification"]
-    D -->|THEOLOGY| E["Weight Profile:<br/>vw=0.9, gw=0.1, k=5"]
-    D -->|GENEALOGY| F["Weight Profile:<br/>vw=0.1, gw=0.9, k=6<br/>Fast: vw=0.8, gw=0.2"]
-    D -->|GEOGRAPHY| G["Weight Profile:<br/>vw=0.5, gw=0.5, k=8"]
-    D -->|CHRONOLOGY| H["Weight Profile:<br/>vw=0.4, gw=0.6, k=8"]
-    D -->|GENERAL| I["Weight Profile:<br/>vw=0.8, gw=0.2, k=5"]
+    D -->|THEOLOGY| E["Weight Profile:<br/>vw=0.63, gw=0.07, bw=0.30, k=5"]
+    D -->|GENEALOGY| F["Weight Profile:<br/>vw=0.15, gw=0.70, bw=0.15, k=6<br/>Fast: vw=0.68, gw=0.17, bw=0.15"]
+    D -->|GEOGRAPHY| G["Weight Profile:<br/>vw=0.30, gw=0.30, bw=0.40, k=8"]
+    D -->|CHRONOLOGY| H["Weight Profile:<br/>vw=0.35, gw=0.40, bw=0.25, k=8"]
+    D -->|GENERAL| I["Weight Profile:<br/>vw=0.48, gw=0.12, bw=0.40, k=5"]
     
     E --> J["Hybrid Retriever"]
     F --> J
@@ -38,18 +38,20 @@ graph TD
     
     J -->|adaptive fanout| K{"Check<br/>Weights"}
     K -->|vw <= 0.1| L["Skip Vector"]
-    K -->|gw > 0.25| M["Run Graph"]
-    K -->|gw <= 0.25| N["Skip Graph"]
-    K -->|else| O["Run Both"]
+    K -->|gw <= 0.1| N["Skip Graph"]
+    K -->|bw <= 0.05| P0["Skip BM25"]
+    K -->|otherwise| O["Run Enabled Paths"]
     
-    L --> P["Vector Search"]
-    M --> Q["Graph Search"]
+    O --> P["Vector Search"]
+    O --> Q["Graph Search"]
+    O --> R0["BM25 Search"]
+    L --> Q
     N --> P
-    O --> P
-    O --> Q
+    P0 --> P
     
     P --> R["Reciprocal Rank<br/>Fusion"]
     Q --> R
+    R0 --> R
     
     R -->|top k verses| S["Entity Fact<br/>Augmentation"]
     S -->|genealogy query?| T["Lexical Rerank<br/>by Query Overlap"]
@@ -98,16 +100,16 @@ Heuristic Intent Detection
   ↓
 [Fallback to intent config OR try LLM if heuristic uncertain]
   ↓
-Output: { intent, vectorWeight, graphWeight, k, filters }
+Output: { intent, vectorWeight, graphWeight, bm25Weight, k, filters }
   ↓
 [If genealogy + direct kinship pattern detected]
-  └─ Apply fast profile: { vw: 0.8, gw: 0.2, k: 6 }
+  └─ Apply fast profile: { vw: 0.68, gw: 0.17, bw: 0.15, k: 6 }
 ```
 
 **Key Optimizations**:
 - Kinship fast profile for genealogy: drops latency 6.6s → ~2s
 - Christology keywords added (Jesus, Christ, Messias)
-- GENERAL weight bumped to vector-only (0.8/0.2 to skip slow graph)
+- GENERAL profile tuned to `0.48/0.12/0.40` for balanced vector+BM25 retrieval
 
 ---
 
@@ -133,11 +135,12 @@ Output: { intent, vectorWeight, graphWeight, k, filters }
 **Adaptive Fanout** (New):
 ```
 if (vectorWeight <= 0.1) skip vectorSearch
-if (graphWeight <= 0.25) skip graphSearch
-else run both with dynamic k multiplier
+if (graphWeight <= 0.1) skip graphSearch
+if (bm25Weight <= 0.05) skip bm25Search
+else run enabled paths with dynamic k multipliers
 ```
 
-Result: For GENERAL/THEOLOGY (low graph weight), graph search is skipped entirely, saving 3–7s latency.
+Result: THEOLOGY usually skips graph (`gw=0.07`), while GENERAL keeps a light graph path (`gw=0.12`) and relies strongly on BM25.
 
 **Entity Enrichment**:
 - Aggregation pipeline: match entities → lookup relations → resolve targets
@@ -247,8 +250,8 @@ Result: TTFT (Time To First Token) < 1.5s after retrieval completes; no monolith
 ```
 Phase 1: Routing (heuristic)         ~0ms
 Phase 2: Vector Search                 ~1s (cold), ~100ms (warm)
-Phase 3: Graph Search                  SKIPPED (gw=0.1 < 0.25)
-Phase 4: RRF + Entity Enrichment      ~300ms
+Phase 3: Graph Search                  SKIPPED (gw=0.07 <= 0.1)
+Phase 4: BM25 + RRF + Entity Enrichment ~300ms
 Phase 5: LLM Generation                ~1.5s (cold), ~500ms (warm)
 ─────────────────────────────────────────────
 Total                                  ~2.8s (cold), ~0.6s+TTFT (stream)
@@ -258,9 +261,9 @@ Total                                  ~2.8s (cold), ~0.6s+TTFT (stream)
 
 ```
 Phase 1: Routing (heuristic kinship)   ~0ms
-         Apply fast profile: vw=0.8, gw=0.2, k=6
+         Apply fast profile: vw=0.68, gw=0.17, bw=0.15, k=6
 Phase 2: Vector Search                 ~1s (cold)
-Phase 3: Graph Search                  SKIPPED (gw=0.2 < 0.25)
+Phase 3: Graph Search                  ACTIVE (gw=0.17 > 0.1)
 Phase 4: RRF + Lexical Rerank          ~300ms
 Phase 5: LLM Generation                ~1.5s (cold)
 ─────────────────────────────────────────────
@@ -288,6 +291,7 @@ User Query
   ├─ Adaptive Fanout Decision
   ├─ Vector Search (semantic)
   ├─ Graph Search (structural) [maybe skipped]
+  ├─ BM25 Search (lexical) [maybe skipped]
   ├─ RRF Fusion
   └─ Entity Enrichment
   ↓
@@ -335,7 +339,7 @@ User Query
 
 - Intent distribution (what % genealogy vs theology?)
 - Cache hit ratio (embedding + retrieve caches)
-- Graph skip rate (should be high for GENERAL/THEOLOGY)
+- Graph/BM25 skip rates by intent (THEOLOGY should skip graph often)
 - TTFT for streaming queries
 - Citation validation failure rate
 

--- a/docs/hybrid-retriever.md
+++ b/docs/hybrid-retriever.md
@@ -5,6 +5,7 @@
 
 - vector search (semantic similarity with OpenAI embeddings + MongoDB vector index),
 - graph search (entity-driven retrieval with `entity_slugs`),
+- BM25 search (lexical relevance via Meilisearch),
 - rank fusion (RRF) to merge both result sets.
 
 It returns:
@@ -20,13 +21,16 @@ It returns:
 2. Return cached payload if available (`retrieveCache`).
 3. Apply **adaptive fanout**:
    - If `vectorWeight <= 0.1`: skip vector search entirely (resolve to empty).
-   - If `graphWeight <= 0.25`: skip graph search entirely (resolve to empty).
-   - Otherwise: use fanout multiplier based on intent:
+   - If `graphWeight <= 0.1`: skip graph search entirely (resolve to empty).
+   - If `bm25Weight <= 0.05`: skip BM25 search entirely (resolve to empty).
+   - Otherwise: use fanout multipliers:
      - `vectorSearchK = (vectorWeight <= 0.15) ? max(4, k) : k * 2`
-     - `graphSearchK = (graphWeight >= 0.8) ? max(k + 2, 8) : k * 2`
+     - `graphSearchK = (graphWeight >= 0.7) ? max(k + 2, 8) : k * 2`
+     - `bm25SearchK = (bm25Weight >= 0.35) ? max(k + 3, 10) : k * 2`
 4. Run in parallel (both or single-sided):
    - `vectorSearch(query, vectorSearchK, filters)`
    - `graphSearch(query, graphSearchK, filters)`
+   - `bm25Search(query, bm25SearchK, filters)`
 5. Merge both lists using `reciprocalRankFusion(...)`.
 6. Keep top `k` verses above `minScore`.
 7. Resolve entity slugs:
@@ -54,9 +58,10 @@ It returns:
 - Returns `RankedVerseResult[]` with source `"graph"`.
 
 ### 3) Fusion: `reciprocalRankFusion`
-- Combines vector + graph rankings with configurable weights:
+- Combines vector + graph + BM25 rankings with configurable weights:
   - `vectorWeight`
   - `graphWeight`
+   - `bm25Weight`
 - Produces final hybrid score and source `"hybrid"`.
 
 ---
@@ -110,35 +115,35 @@ Both caches are in-memory TTL maps with max-size eviction.
 
 ## Weight presets (from Query Router)
 
-| Intent | Vector | Graph | k | Use Case |
-|--------|--------|-------|---|----------|
-| **THEOLOGY** | 0.9 | 0.1 | 5 | Thematic: "What does Bible say about faith?" |
-| **GENEALOGY** | 0.1 | 0.9 | 6 | Kinship: "Father of Jacob?" → *fast profile: 0.8/0.2 after routing* |
-| **GEOGRAPHY** | 0.5 | 0.5 | 8 | Places: "Abraham in Egypt?" |
-| **CHRONOLOGY** | 0.4 | 0.6 | 8 | Timeline: "What happened after X?" |
-| **GENERAL** | 0.8 | 0.2 | 5 | Fallback (vector-only with graph skip) |
+| Intent | Vector | Graph | BM25 | k | Use Case |
+|--------|--------|-------|------|---|----------|
+| **THEOLOGY** | 0.63 | 0.07 | 0.30 | 5 | Thematic: "Que dit la Bible sur la foi ?" |
+| **GENEALOGY** | 0.15 | 0.70 | 0.15 | 6 | Kinship: "Qui est le fils de Jacob ?" |
+| **GEOGRAPHY** | 0.30 | 0.30 | 0.40 | 8 | Places: "Abraham en Egypte ?" |
+| **CHRONOLOGY** | 0.35 | 0.40 | 0.25 | 8 | Timeline: "Que se passe-t-il apres X ?" |
+| **GENERAL** | 0.48 | 0.12 | 0.40 | 5 | Fallback balanced profile |
 
-*Note: Kinship fast profile applied dynamically by router when direct kinship detected.*
+*Note: direct kinship fast profile is applied dynamically as `0.68/0.17/0.15`.*
 
 ---
 
 ## Optimization: Adaptive fanout & kinship fast profile
 
 ### Context
-- **Genealogy queries** (`"fils de"`, `"son of"`, etc.) benefit from high graph weight but graph search is slow (~3–7s cold).
-- **Theology/General queries** are fast with vector-only but GENERAL used to run full hybrid (added latency + noise).
+- **Genealogy queries** (`"fils de"`, `"son of"`, etc.) still benefit from graph-heavy routing.
+- **Theology queries** (`gw=0.07`) usually skip graph due adaptive fanout threshold (`gw <= 0.1`).
 
 ### Solutions
 1. **Kinship fast profile** (from Query Router):
    - Direct kinship patterns detected in `query-router.ts` → `isDirectKinshipQuestion`
-   - Routes genealogy to `vectorWeight: 0.8, graphWeight: 0.2, k: 6` (fast)
-   - Skips graph search via adaptive fanout when `gw <= 0.25`
+   - Routes genealogy to `vectorWeight: 0.68, graphWeight: 0.17, bm25Weight: 0.15, k: 6` (fast)
+   - Keeps graph active (`gw=0.17`) while reducing graph dominance/noise
    - Result: genealogy queries drop from 6.6s → ~2s cold, correct Genesis verses for Joseph query
 
 2. **THEOLOGY weight bump + Christology keywords** (from Query Router US-009 refinement):
    - Added `"jesus"`, `"jésus"`, `"christ"`, `"messie"` to heuristic intent detection
-   - Adjusted `GENERAL: { vw: 0.8, gw: 0.2 }` (was 0.7/0.3)
-   - Ensures pure-vector queries stay <2s, irrelevant graph results skipped
+   - Current defaults use BM25-aware profiles (THEOLOGY `0.63/0.07/0.30`, GENERAL `0.48/0.12/0.40`)
+   - Keeps lexical recall while reducing graph overhead for theology
 
 3. **Genealogy lexical boost** (`rerankByQueryOverlap`):
    - If query looks genealogical, re-rank results by token overlap with query

--- a/search-engine/public/openapi.json
+++ b/search-engine/public/openapi.json
@@ -46,7 +46,7 @@
               "examples": {
                 "basic": {
                   "value": {
-                    "query": "faith and perseverance",
+                    "query": "foi et perseverance",
                     "k": 5,
                     "minScore": 0.6,
                     "filters": {
@@ -110,7 +110,7 @@
               "examples": {
                 "genealogy": {
                   "value": {
-                    "query": "Who is the son of Joseph?",
+                    "query": "Qui est le fils de Joseph ?",
                     "k": 8,
                     "vectorWeight": 0.2,
                     "graphWeight": 0.7,
@@ -120,7 +120,7 @@
                 },
                 "theology": {
                   "value": {
-                    "query": "What does the Bible say about faith?",
+                    "query": "Que dit la Bible au sujet de la foi ?",
                     "k": 5,
                     "vectorWeight": 0.6,
                     "graphWeight": 0.1,
@@ -193,7 +193,7 @@
               "examples": {
                 "jsonMode": {
                   "value": {
-                    "query": "What does Romans say about faith?",
+                    "query": "Que dit Romains au sujet de la foi ?",
                     "stream": false,
                     "k": 6,
                     "vectorWeight": 0.7,
@@ -202,7 +202,7 @@
                 },
                 "streamMode": {
                   "value": {
-                    "query": "Who are the relatives of Jacob?",
+                    "query": "Qui sont les proches de Jacob ?",
                     "stream": true
                   }
                 }
@@ -280,7 +280,7 @@
                     "messages": [
                       {
                         "role": "user",
-                        "content": "Who is Abraham?"
+                        "content": "Qui est Abraham ?"
                       }
                     ]
                   }

--- a/search-engine/public/openapi.json
+++ b/search-engine/public/openapi.json
@@ -99,7 +99,7 @@
           "Hybrid"
         ],
         "summary": "Hybrid search",
-        "description": "Combines vector retrieval and graph retrieval with routing.",
+        "description": "Combines vector, graph, and BM25 retrieval with routing.",
         "requestBody": {
           "required": true,
           "content": {
@@ -182,7 +182,7 @@
           "Answer"
         ],
         "summary": "Generate grounded answer",
-        "description": "Generates an answer grounded in retrieved verses and entity facts. Supports JSON or SSE stream output.",
+        "description": "Generates an answer grounded in retrieved verses and entity facts. Supports JSON or SSE stream output. Retrieval routing remains BM25-aware internally.",
         "requestBody": {
           "required": true,
           "content": {
@@ -195,14 +195,12 @@
                   "value": {
                     "query": "Que dit Romains au sujet de la foi ?",
                     "stream": false,
-                    "k": 6,
-                    "vectorWeight": 0.7,
-                    "graphWeight": 0.3
+                    "k": 6
                   }
                 },
                 "streamMode": {
                   "value": {
-                    "query": "Qui sont les proches de Jacob ?",
+                    "query": "Qui est le fils de Jacob ?",
                     "stream": true
                   }
                 }

--- a/search-engine/src/openapi/spec.ts
+++ b/search-engine/src/openapi/spec.ts
@@ -75,7 +75,7 @@ export const openApiSpec = {
       post: {
         tags: ["Hybrid"],
         summary: "Hybrid search",
-        description: "Combines vector retrieval and graph retrieval with routing.",
+        description: "Combines vector, graph, and BM25 retrieval with routing.",
         requestBody: {
           required: true,
           content: {
@@ -147,7 +147,7 @@ export const openApiSpec = {
         tags: ["Answer"],
         summary: "Generate grounded answer",
         description:
-          "Generates an answer grounded in retrieved verses and entity facts. Supports JSON or SSE stream output.",
+          "Generates an answer grounded in retrieved verses and entity facts. Supports JSON or SSE stream output. Retrieval routing remains BM25-aware internally.",
         requestBody: {
           required: true,
           content: {
@@ -159,13 +159,11 @@ export const openApiSpec = {
                     query: "Que dit Romains au sujet de la foi ?",
                     stream: false,
                     k: 6,
-                    vectorWeight: 0.7,
-                    graphWeight: 0.3,
                   },
                 },
                 streamMode: {
                   value: {
-                    query: "Qui sont les proches de Jacob ?",
+                    query: "Qui est le fils de Jacob ?",
                     stream: true,
                   },
                 },

--- a/search-engine/src/openapi/spec.ts
+++ b/search-engine/src/openapi/spec.ts
@@ -33,7 +33,7 @@ export const openApiSpec = {
               examples: {
                 basic: {
                   value: {
-                    query: "faith and perseverance",
+                    query: "foi et perseverance",
                     k: 5,
                     minScore: 0.6,
                     filters: { testament: "New", book: "Hebrews" },
@@ -84,7 +84,7 @@ export const openApiSpec = {
               examples: {
                 genealogy: {
                   value: {
-                    query: "Who is the son of Joseph?",
+                    query: "Qui est le fils de Joseph ?",
                     k: 8,
                     vectorWeight: 0.2,
                     graphWeight: 0.7,
@@ -94,7 +94,7 @@ export const openApiSpec = {
                 },
                 theology: {
                   value: {
-                    query: "What does the Bible say about faith?",
+                    query: "Que dit la Bible au sujet de la foi ?",
                     k: 5,
                     vectorWeight: 0.6,
                     graphWeight: 0.1,
@@ -156,7 +156,7 @@ export const openApiSpec = {
               examples: {
                 jsonMode: {
                   value: {
-                    query: "What does Romans say about faith?",
+                    query: "Que dit Romains au sujet de la foi ?",
                     stream: false,
                     k: 6,
                     vectorWeight: 0.7,
@@ -165,7 +165,7 @@ export const openApiSpec = {
                 },
                 streamMode: {
                   value: {
-                    query: "Who are the relatives of Jacob?",
+                    query: "Qui sont les proches de Jacob ?",
                     stream: true,
                   },
                 },
@@ -230,7 +230,7 @@ export const openApiSpec = {
                 ask: {
                   value: {
                     messages: [
-                      { role: "user", content: "Who is Abraham?" },
+                      { role: "user", content: "Qui est Abraham ?" },
                     ],
                   },
                 },


### PR DESCRIPTION
## Summary
Translate OpenAPI example query texts to French while keeping route/schema behavior unchanged.

## Changes
- Updated French query examples in `search-engine/src/openapi/spec.ts`
- Regenerated `search-engine/public/openapi.json`

## Validation
- `npm run generate:openapi`
- `npx vitest run src/__tests__/hybrid-search.test.ts`
- Result: 1 file passed, 10 tests passed

## Notes
- This is a docs/spec content update only (no runtime logic changes).
