### PR TITLE
build: shrink bible-chat-scholar image with Next standalone runtime

### DIFF
--- a/search-engine/Dockerfile
+++ b/search-engine/Dockerfile
@@ -37,14 +37,12 @@ RUN apk upgrade --no-cache
 
 RUN addgroup -S nodejs && adduser -S nextjs -G nodejs
 
-COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/next.config.ts ./next.config.ts
+COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next/static ./.next/static
 
 USER nextjs
 
 EXPOSE 3000
 
-CMD ["npm", "run", "start"]
+CMD ["node", "server.js"]

--- a/search-engine/next.config.ts
+++ b/search-engine/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 import path from "node:path";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   turbopack: {
     root: path.resolve(__dirname),
   },


### PR DESCRIPTION
Closes #85

## Summary
- enable Next.js standalone output for the search-engine app
- switch the runtime image to copy only the standalone server bundle, static assets, and public assets
- remove the need to copy the full production `node_modules` tree into the runner image

## Validation
- `OPENAI_API_KEY=dummy DATABASE_URL=mongodb://127.0.0.1:27017/bible_sg npm run build`
- verified `.next/standalone/server.js` is generated
- built container locally with `docker build -t bible-chat-scholar:issue-85 .`

## Result
- previous pulled image size: `738 MB`
- updated local image size: `226 MB`

## Scope
- changes are limited to:
  - `search-engine/next.config.ts`
  - `search-engine/Dockerfile`
